### PR TITLE
chore: add bun lockfiles to .gitignore

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -8,6 +8,8 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+bun.lock
+bun.lockb
 .DS_Store
 dist
 dist-ssr


### PR DESCRIPTION
The project's README documents an npm based workflow, so `bun.lock` and `bun.lockb` are not part of the default setup. Users running Bun locally would otherwise accidentally commit their lockfile alongside npm's.

Both the current text-based (`bun.lock`) and legacy binary (`bun.lockb`) formats are covered.