### PR TITLE
fix: replace misleading Max ratings input with Show ratings toggle

### DIFF
--- a/api/src/entity/api_key_settings.rs
+++ b/api/src/entity/api_key_settings.rs
@@ -32,6 +32,10 @@ pub struct Model {
     pub episode_position: String,
     pub episode_badge_direction: String,
     pub episode_blur: bool,
+    pub ratings_enabled: bool,
+    pub logo_ratings_enabled: bool,
+    pub backdrop_ratings_enabled: bool,
+    pub episode_ratings_enabled: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/api/src/handlers/admin.rs
+++ b/api/src/handlers/admin.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::cache;
 use crate::error::AppError;
 use crate::image::serve::{self, LogoBackdropKind};
-use crate::services::db::{self, default_ratings_limit, default_logo_backdrop_ratings_limit, default_ratings_order, BadgeDirection, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, ImageSource};
+use crate::services::db::{self, default_ratings_enabled, default_ratings_limit, default_logo_backdrop_ratings_limit, default_ratings_order, BadgeDirection, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, ImageSource};
 use crate::AppState;
 
 #[derive(Serialize)]
@@ -114,12 +114,15 @@ pub struct GlobalSettingsResponse {
     pub lang: String,
     pub textless: bool,
     pub fanart_available: bool,
+    pub ratings_enabled: bool,
     pub ratings_limit: i32,
     pub ratings_order: String,
     pub free_api_key_enabled: bool,
     pub free_api_key_locked: bool,
     pub poster_position: BadgePosition,
+    pub logo_ratings_enabled: bool,
     pub logo_ratings_limit: i32,
+    pub backdrop_ratings_enabled: bool,
     pub backdrop_ratings_limit: i32,
     pub poster_badge_style: BadgeStyle,
     pub logo_badge_style: BadgeStyle,
@@ -133,6 +136,7 @@ pub struct GlobalSettingsResponse {
     pub backdrop_badge_size: BadgeSize,
     pub backdrop_position: BadgePosition,
     pub backdrop_badge_direction: BadgeDirection,
+    pub episode_ratings_enabled: bool,
     pub episode_ratings_limit: i32,
     pub episode_badge_style: BadgeStyle,
     pub episode_label_style: LabelStyle,
@@ -161,12 +165,15 @@ pub async fn get_settings(
         lang: settings.lang.to_string(),
         textless: settings.textless,
         fanart_available: state.fanart.is_some(),
+        ratings_enabled: settings.ratings_enabled,
         ratings_limit: settings.ratings_limit,
         ratings_order: settings.ratings_order.to_string(),
         free_api_key_enabled,
         free_api_key_locked,
         poster_position: settings.poster_position,
+        logo_ratings_enabled: settings.logo_ratings_enabled,
         logo_ratings_limit: settings.logo_ratings_limit,
+        backdrop_ratings_enabled: settings.backdrop_ratings_enabled,
         backdrop_ratings_limit: settings.backdrop_ratings_limit,
         poster_badge_style: settings.poster_badge_style,
         logo_badge_style: settings.logo_badge_style,
@@ -180,6 +187,7 @@ pub async fn get_settings(
         backdrop_badge_size: settings.backdrop_badge_size,
         backdrop_position: settings.backdrop_position,
         backdrop_badge_direction: settings.backdrop_badge_direction,
+        episode_ratings_enabled: settings.episode_ratings_enabled,
         episode_ratings_limit: settings.episode_ratings_limit,
         episode_badge_style: settings.episode_badge_style,
         episode_label_style: settings.episode_label_style,
@@ -198,6 +206,8 @@ pub struct UpdateGlobalSettingsRequest {
     pub lang: String,
     #[serde(default, alias = "fanart_textless")]
     pub textless: bool,
+    #[serde(default = "default_ratings_enabled")]
+    pub ratings_enabled: bool,
     #[serde(default = "default_ratings_limit")]
     pub ratings_limit: i32,
     #[serde(default = "default_ratings_order")]
@@ -205,8 +215,12 @@ pub struct UpdateGlobalSettingsRequest {
     pub free_api_key_enabled: Option<bool>,
     #[serde(default = "db::default_poster_position")]
     pub poster_position: BadgePosition,
+    #[serde(default = "default_ratings_enabled")]
+    pub logo_ratings_enabled: bool,
     #[serde(default = "default_logo_backdrop_ratings_limit")]
     pub logo_ratings_limit: i32,
+    #[serde(default = "default_ratings_enabled")]
+    pub backdrop_ratings_enabled: bool,
     #[serde(default = "default_logo_backdrop_ratings_limit")]
     pub backdrop_ratings_limit: i32,
     #[serde(default = "db::default_poster_badge_style")]
@@ -233,6 +247,8 @@ pub struct UpdateGlobalSettingsRequest {
     pub backdrop_position: BadgePosition,
     #[serde(default = "db::default_backdrop_badge_direction")]
     pub backdrop_badge_direction: BadgeDirection,
+    #[serde(default = "default_ratings_enabled")]
+    pub episode_ratings_enabled: bool,
     #[serde(default = "db::default_episode_ratings_limit")]
     pub episode_ratings_limit: i32,
     #[serde(default = "db::default_episode_badge_style")]
@@ -255,6 +271,10 @@ pub async fn update_settings(
 ) -> Result<Json<serde_json::Value>, AppError> {
     db::validate_render_settings(&req.lang, req.ratings_limit, &req.ratings_order, req.logo_ratings_limit, req.backdrop_ratings_limit, req.episode_ratings_limit)?;
     let textless_str = if req.textless { "true" } else { "false" };
+    let ratings_enabled_str = if req.ratings_enabled { "true" } else { "false" };
+    let logo_ratings_enabled_str = if req.logo_ratings_enabled { "true" } else { "false" };
+    let backdrop_ratings_enabled_str = if req.backdrop_ratings_enabled { "true" } else { "false" };
+    let episode_ratings_enabled_str = if req.episode_ratings_enabled { "true" } else { "false" };
     let limit_str = req.ratings_limit.to_string();
     let logo_limit_str = req.logo_ratings_limit.to_string();
     let backdrop_limit_str = req.backdrop_ratings_limit.to_string();
@@ -264,8 +284,12 @@ pub async fn update_settings(
         ("image_source", req.image_source.as_str()),
         ("lang", &req.lang),
         ("textless", textless_str),
+        ("ratings_enabled", ratings_enabled_str),
         ("ratings_limit", &limit_str),
         ("ratings_order", &req.ratings_order),
+        ("logo_ratings_enabled", logo_ratings_enabled_str),
+        ("backdrop_ratings_enabled", backdrop_ratings_enabled_str),
+        ("episode_ratings_enabled", episode_ratings_enabled_str),
         ("poster_position", req.poster_position.as_str()),
         ("logo_ratings_limit", &logo_limit_str),
         ("backdrop_ratings_limit", &backdrop_limit_str),

--- a/api/src/handlers/api_keys.rs
+++ b/api/src/handlers/api_keys.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use super::auth::AuthUser;
 use super::middleware::ApiKeyUser;
 use crate::error::AppError;
-use crate::services::db::{self, default_ratings_limit, default_logo_backdrop_ratings_limit, default_ratings_order, BadgeDirection, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, ImageSource};
+use crate::services::db::{self, default_ratings_enabled, default_ratings_limit, default_logo_backdrop_ratings_limit, default_ratings_order, BadgeDirection, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, ImageSource};
 use crate::services::validation;
 use crate::AppState;
 
@@ -98,10 +98,13 @@ pub struct RenderSettingsResponse {
     pub textless: bool,
     pub fanart_available: bool,
     pub is_default: bool,
+    pub ratings_enabled: bool,
     pub ratings_limit: i32,
     pub ratings_order: String,
     pub poster_position: BadgePosition,
+    pub logo_ratings_enabled: bool,
     pub logo_ratings_limit: i32,
+    pub backdrop_ratings_enabled: bool,
     pub backdrop_ratings_limit: i32,
     pub poster_badge_style: BadgeStyle,
     pub logo_badge_style: BadgeStyle,
@@ -115,6 +118,7 @@ pub struct RenderSettingsResponse {
     pub backdrop_badge_size: BadgeSize,
     pub backdrop_position: BadgePosition,
     pub backdrop_badge_direction: BadgeDirection,
+    pub episode_ratings_enabled: bool,
     pub episode_ratings_limit: i32,
     pub episode_badge_style: BadgeStyle,
     pub episode_label_style: LabelStyle,
@@ -142,10 +146,13 @@ fn settings_to_response(settings: &db::RenderSettings, fanart_available: bool) -
         textless: settings.textless,
         fanart_available,
         is_default: settings.is_default,
+        ratings_enabled: settings.ratings_enabled,
         ratings_limit: settings.ratings_limit,
         ratings_order: settings.ratings_order.to_string(),
         poster_position: settings.poster_position,
+        logo_ratings_enabled: settings.logo_ratings_enabled,
         logo_ratings_limit: settings.logo_ratings_limit,
+        backdrop_ratings_enabled: settings.backdrop_ratings_enabled,
         backdrop_ratings_limit: settings.backdrop_ratings_limit,
         poster_badge_style: settings.poster_badge_style,
         logo_badge_style: settings.logo_badge_style,
@@ -159,6 +166,7 @@ fn settings_to_response(settings: &db::RenderSettings, fanart_available: bool) -
         backdrop_badge_size: settings.backdrop_badge_size,
         backdrop_position: settings.backdrop_position,
         backdrop_badge_direction: settings.backdrop_badge_direction,
+        episode_ratings_enabled: settings.episode_ratings_enabled,
         episode_ratings_limit: settings.episode_ratings_limit,
         episode_badge_style: settings.episode_badge_style,
         episode_label_style: settings.episode_label_style,
@@ -177,14 +185,20 @@ pub struct UpdateSettingsRequest {
     pub lang: String,
     #[serde(default, alias = "fanart_textless")]
     pub textless: bool,
+    #[serde(default = "default_ratings_enabled")]
+    pub ratings_enabled: bool,
     #[serde(default = "default_ratings_limit")]
     pub ratings_limit: i32,
     #[serde(default = "default_ratings_order")]
     pub ratings_order: String,
     #[serde(default = "db::default_poster_position")]
     pub poster_position: BadgePosition,
+    #[serde(default = "default_ratings_enabled")]
+    pub logo_ratings_enabled: bool,
     #[serde(default = "default_logo_backdrop_ratings_limit")]
     pub logo_ratings_limit: i32,
+    #[serde(default = "default_ratings_enabled")]
+    pub backdrop_ratings_enabled: bool,
     #[serde(default = "default_logo_backdrop_ratings_limit")]
     pub backdrop_ratings_limit: i32,
     #[serde(default = "db::default_poster_badge_style")]
@@ -211,6 +225,8 @@ pub struct UpdateSettingsRequest {
     pub backdrop_position: BadgePosition,
     #[serde(default = "db::default_backdrop_badge_direction")]
     pub backdrop_badge_direction: BadgeDirection,
+    #[serde(default = "default_ratings_enabled")]
+    pub episode_ratings_enabled: bool,
     #[serde(default = "db::default_episode_ratings_limit")]
     pub episode_ratings_limit: i32,
     #[serde(default = "db::default_episode_badge_style")]
@@ -233,10 +249,13 @@ fn build_upsert(id: i32, req: &UpdateSettingsRequest) -> db::UpsertApiKeySetting
         image_source: req.image_source.as_str(),
         lang: &req.lang,
         textless: req.textless,
+        ratings_enabled: req.ratings_enabled,
         ratings_limit: req.ratings_limit,
         ratings_order: &req.ratings_order,
         poster_position: req.poster_position.as_str(),
+        logo_ratings_enabled: req.logo_ratings_enabled,
         logo_ratings_limit: req.logo_ratings_limit,
+        backdrop_ratings_enabled: req.backdrop_ratings_enabled,
         backdrop_ratings_limit: req.backdrop_ratings_limit,
         poster_badge_style: req.poster_badge_style.as_str(),
         logo_badge_style: req.logo_badge_style.as_str(),
@@ -250,6 +269,7 @@ fn build_upsert(id: i32, req: &UpdateSettingsRequest) -> db::UpsertApiKeySetting
         backdrop_badge_size: req.backdrop_badge_size.as_str(),
         backdrop_position: req.backdrop_position.as_str(),
         backdrop_badge_direction: req.backdrop_badge_direction.as_str(),
+        episode_ratings_enabled: req.episode_ratings_enabled,
         episode_ratings_limit: req.episode_ratings_limit,
         episode_badge_style: req.episode_badge_style.as_str(),
         episode_label_style: req.episode_label_style.as_str(),

--- a/api/src/image/serve.rs
+++ b/api/src/image/serve.rs
@@ -123,10 +123,10 @@ pub fn settings_cache_suffix(
     image_size: Option<ImageSize>,
 ) -> String {
     let ratings_suffix = match kind {
-        cache::ImageType::Poster => ratings::ratings_cache_suffix(&settings.ratings_order, settings.ratings_limit),
-        cache::ImageType::Logo => ratings::ratings_cache_suffix(&settings.ratings_order, settings.logo_ratings_limit),
-        cache::ImageType::Backdrop => ratings::ratings_cache_suffix(&settings.ratings_order, settings.backdrop_ratings_limit),
-        cache::ImageType::Episode => ratings::ratings_cache_suffix(&settings.ratings_order, settings.episode_ratings_limit),
+        cache::ImageType::Poster => ratings::ratings_cache_suffix(&settings.ratings_order, settings.effective_ratings_limit()),
+        cache::ImageType::Logo => ratings::ratings_cache_suffix(&settings.ratings_order, settings.effective_logo_ratings_limit()),
+        cache::ImageType::Backdrop => ratings::ratings_cache_suffix(&settings.ratings_order, settings.effective_backdrop_ratings_limit()),
+        cache::ImageType::Episode => ratings::ratings_cache_suffix(&settings.ratings_order, settings.effective_episode_ratings_limit()),
     };
     settings_cache_suffix_with_ratings(settings, kind, image_size, &ratings_suffix)
 }
@@ -172,6 +172,10 @@ pub fn settings_cache_suffix_with_ratings(
         episode_position: _,
         episode_badge_direction: _,
         episode_blur: _,
+        ratings_enabled: _,
+        logo_ratings_enabled: _,
+        backdrop_ratings_enabled: _,
+        episode_ratings_enabled: _,
     } = settings;
 
     let resolved_size = resolve_image_size(image_size);
@@ -616,7 +620,7 @@ pub async fn handle_inner(
         let fast_path_start = Instant::now();
         if let Some(available) = read_available_ratings_cached(state, &id_key).await {
             let available_ratings_ms = fast_path_start.elapsed().as_millis() as u64;
-            let ratings_suffix = ratings::badges_suffix_from_available(&available, &settings.ratings_order, settings.ratings_limit);
+            let ratings_suffix = ratings::badges_suffix_from_available(&available, &settings.ratings_order, settings.effective_ratings_limit());
             let suffix = settings_cache_suffix_with_ratings(&settings, cache::ImageType::Poster, image_size, &ratings_suffix);
             let cache_value = format!("{id_value}{variant}{suffix}");
             let cache_path = cache::typed_cache_path(&state.config.cache_dir, cache::ImageType::Poster, id_type_str, &cache_value)?;
@@ -693,7 +697,7 @@ pub async fn handle_inner(
     // TMDB path (default, or fanart fallback)
     let settings = &settings;
 
-    let badges = ratings::apply_rating_preferences(ratings_result.badges, &settings.ratings_order, settings.ratings_limit);
+    let badges = ratings::apply_rating_preferences(ratings_result.badges, &settings.ratings_order, settings.effective_ratings_limit());
     let ratings_suffix = ratings::badges_cache_suffix(&badges);
 
     let suffix = settings_cache_suffix_with_ratings(settings, cache::ImageType::Poster, image_size, &ratings_suffix);
@@ -838,7 +842,7 @@ async fn try_fanart_path(
         return Ok(None);
     }
 
-    let badges = ratings::apply_rating_preferences(ratings_result.badges.clone(), &settings.ratings_order, settings.ratings_limit);
+    let badges = ratings::apply_rating_preferences(ratings_result.badges.clone(), &settings.ratings_order, settings.effective_ratings_limit());
     let ratings_suffix = ratings::badges_cache_suffix(&badges);
 
     // Compute settings suffix once for all fanart variants
@@ -989,7 +993,7 @@ fn trigger_background_refresh(
             let sources = ratings::available_sources_string(&ratings_result.badges);
             upsert_available_ratings_cached(&state2, &id_key, &sources, cross_ids.release_date.as_deref()).await;
         }
-        let badges = ratings::apply_rating_preferences(ratings_result.badges, &settings.ratings_order, settings.ratings_limit);
+        let badges = ratings::apply_rating_preferences(ratings_result.badges, &settings.ratings_order, settings.effective_ratings_limit());
         let (bytes, rd, _tier, cross_ids) =
             generate_poster_with_source(&state2, &resolved, badges, &cross_ids, &settings, image_size, false).await?;
         Ok((bytes, rd, cache::ImageType::Poster, cross_ids))
@@ -1030,8 +1034,8 @@ fn trigger_logo_backdrop_refresh(
             upsert_available_ratings_cached(&state2, &id_key, &sources, cross_ids.release_date.as_deref()).await;
         }
         let type_ratings_limit = match lb_kind {
-            LogoBackdropKind::Logo => settings.logo_ratings_limit,
-            LogoBackdropKind::Backdrop => settings.backdrop_ratings_limit,
+            LogoBackdropKind::Logo => settings.effective_logo_ratings_limit(),
+            LogoBackdropKind::Backdrop => settings.effective_backdrop_ratings_limit(),
         };
         let badges = ratings::apply_rating_preferences(ratings_result.badges, &settings.ratings_order, type_ratings_limit);
 
@@ -1179,7 +1183,7 @@ fn trigger_episode_refresh(
             let sources = ratings::available_sources_string(&ratings_result.badges);
             upsert_available_ratings_cached(&state2, &id_key, &sources, cross_ids.release_date.as_deref()).await;
         }
-        let badges = ratings::apply_rating_preferences(ratings_result.badges, &settings.ratings_order, settings.episode_ratings_limit);
+        let badges = ratings::apply_rating_preferences(ratings_result.badges, &settings.ratings_order, settings.effective_episode_ratings_limit());
         let bytes = generate_episode(&state2, &resolved, badges, &settings, image_size).await?;
 
         Ok((bytes, cross_ids.release_date.clone(), cache::ImageType::Episode, cross_ids))
@@ -1585,7 +1589,7 @@ pub async fn handle_episode_inner(
     // Fast path: try to reconstruct the cache key from SQLite-stored available
     // sources, avoiding external API calls entirely on cache hits.
     if let Some(available) = read_available_ratings_cached(state, &id_key).await {
-        let ratings_suffix = ratings::badges_suffix_from_available(&available, &settings.ratings_order, settings.episode_ratings_limit);
+        let ratings_suffix = ratings::badges_suffix_from_available(&available, &settings.ratings_order, settings.effective_episode_ratings_limit());
         let suffix = settings_cache_suffix_with_ratings(&settings, cache::ImageType::Episode, image_size, &ratings_suffix);
         let cache_value = format!("{id_value}{suffix}");
         let cache_path = cache::typed_cache_path(&state.config.cache_dir, cache::ImageType::Episode, id_type_str, &cache_value)?;
@@ -1627,7 +1631,7 @@ pub async fn handle_episode_inner(
         upsert_available_ratings_cached(state, &id_key, &sources, cross_ids.release_date.as_deref()).await;
     }
 
-    let badges = ratings::apply_rating_preferences(ratings_result.badges, &settings.ratings_order, settings.episode_ratings_limit);
+    let badges = ratings::apply_rating_preferences(ratings_result.badges, &settings.ratings_order, settings.effective_episode_ratings_limit());
     let ratings_suffix = ratings::badges_cache_suffix(&badges);
     let suffix = settings_cache_suffix_with_ratings(&settings, cache::ImageType::Episode, image_size, &ratings_suffix);
     let cache_value = format!("{id_value}{suffix}");
@@ -1691,8 +1695,8 @@ pub async fn handle_logo_backdrop_inner(
 
     // Use per-type rating limit for logos/backdrops
     let type_ratings_limit = match lb_kind {
-        LogoBackdropKind::Logo => settings.logo_ratings_limit,
-        LogoBackdropKind::Backdrop => settings.backdrop_ratings_limit,
+        LogoBackdropKind::Logo => settings.effective_logo_ratings_limit(),
+        LogoBackdropKind::Backdrop => settings.effective_backdrop_ratings_limit(),
     };
     let params = LbRenderParams::from_settings(lb_kind, settings);
     let type_badge_style = params.badge_style;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -340,4 +340,20 @@ pub const MIGRATIONS: &[(&str, &str)] = &[
         "ALTER TABLE api_key_settings ADD COLUMN backdrop_badge_direction TEXT NOT NULL DEFAULT 'v'",
         "duplicate column",
     ),
+    (
+        "ALTER TABLE api_key_settings ADD COLUMN ratings_enabled INTEGER NOT NULL DEFAULT 1",
+        "duplicate column",
+    ),
+    (
+        "ALTER TABLE api_key_settings ADD COLUMN logo_ratings_enabled INTEGER NOT NULL DEFAULT 1",
+        "duplicate column",
+    ),
+    (
+        "ALTER TABLE api_key_settings ADD COLUMN backdrop_ratings_enabled INTEGER NOT NULL DEFAULT 1",
+        "duplicate column",
+    ),
+    (
+        "ALTER TABLE api_key_settings ADD COLUMN episode_ratings_enabled INTEGER NOT NULL DEFAULT 1",
+        "duplicate column",
+    ),
 ];

--- a/api/src/services/db.rs
+++ b/api/src/services/db.rs
@@ -425,6 +425,10 @@ pub fn default_lang() -> String {
     "en".to_string()
 }
 
+pub fn default_ratings_enabled() -> bool {
+    true
+}
+
 pub fn default_ratings_limit() -> i32 {
     3
 }
@@ -1644,6 +1648,10 @@ pub struct UpsertApiKeySettings<'a> {
     pub episode_position: &'a str,
     pub episode_badge_direction: &'a str,
     pub episode_blur: bool,
+    pub ratings_enabled: bool,
+    pub logo_ratings_enabled: bool,
+    pub backdrop_ratings_enabled: bool,
+    pub episode_ratings_enabled: bool,
 }
 
 pub async fn upsert_api_key_settings(
@@ -1679,6 +1687,10 @@ pub async fn upsert_api_key_settings(
         episode_position: Set(params.episode_position.to_string()),
         episode_badge_direction: Set(params.episode_badge_direction.to_string()),
         episode_blur: Set(params.episode_blur),
+        ratings_enabled: Set(params.ratings_enabled),
+        logo_ratings_enabled: Set(params.logo_ratings_enabled),
+        backdrop_ratings_enabled: Set(params.backdrop_ratings_enabled),
+        episode_ratings_enabled: Set(params.episode_ratings_enabled),
     };
     api_key_settings::Entity::insert(model)
         .on_conflict(
@@ -1711,6 +1723,10 @@ pub async fn upsert_api_key_settings(
                     api_key_settings::Column::EpisodePosition,
                     api_key_settings::Column::EpisodeBadgeDirection,
                     api_key_settings::Column::EpisodeBlur,
+                    api_key_settings::Column::RatingsEnabled,
+                    api_key_settings::Column::LogoRatingsEnabled,
+                    api_key_settings::Column::BackdropRatingsEnabled,
+                    api_key_settings::Column::EpisodeRatingsEnabled,
                 ])
                 .to_owned(),
         )
@@ -1738,11 +1754,14 @@ pub struct RenderSettings {
     pub image_source: ImageSource,
     pub lang: Arc<str>,
     pub textless: bool,
+    pub ratings_enabled: bool,
     pub ratings_limit: i32,
     pub ratings_order: Arc<str>,
     pub is_default: bool,
     pub poster_position: BadgePosition,
+    pub logo_ratings_enabled: bool,
     pub logo_ratings_limit: i32,
+    pub backdrop_ratings_enabled: bool,
     pub backdrop_ratings_limit: i32,
     pub poster_badge_style: BadgeStyle,
     pub logo_badge_style: BadgeStyle,
@@ -1756,6 +1775,7 @@ pub struct RenderSettings {
     pub backdrop_badge_size: BadgeSize,
     pub backdrop_position: BadgePosition,
     pub backdrop_badge_direction: BadgeDirection,
+    pub episode_ratings_enabled: bool,
     pub episode_ratings_limit: i32,
     pub episode_badge_style: BadgeStyle,
     pub episode_label_style: LabelStyle,
@@ -1765,17 +1785,35 @@ pub struct RenderSettings {
     pub episode_blur: bool,
 }
 
+impl RenderSettings {
+    pub fn effective_ratings_limit(&self) -> i32 {
+        if self.ratings_enabled { self.ratings_limit } else { 0 }
+    }
+    pub fn effective_logo_ratings_limit(&self) -> i32 {
+        if self.logo_ratings_enabled { self.logo_ratings_limit } else { 0 }
+    }
+    pub fn effective_backdrop_ratings_limit(&self) -> i32 {
+        if self.backdrop_ratings_enabled { self.backdrop_ratings_limit } else { 0 }
+    }
+    pub fn effective_episode_ratings_limit(&self) -> i32 {
+        if self.episode_ratings_enabled { self.episode_ratings_limit } else { 0 }
+    }
+}
+
 impl Default for RenderSettings {
     fn default() -> Self {
         Self {
             image_source: ImageSource::Tmdb,
             lang: Arc::from("en"),
             textless: false,
+            ratings_enabled: true,
             ratings_limit: default_ratings_limit(),
             ratings_order: Arc::from("mal,imdb,lb,rt,mc,rta,tmdb,trakt"),
             is_default: true,
             poster_position: BadgePosition::BottomCenter,
+            logo_ratings_enabled: true,
             logo_ratings_limit: default_logo_backdrop_ratings_limit(),
+            backdrop_ratings_enabled: true,
             backdrop_ratings_limit: default_logo_backdrop_ratings_limit(),
             poster_badge_style: BadgeStyle::Default,
             logo_badge_style: BadgeStyle::Vertical,
@@ -1789,6 +1827,7 @@ impl Default for RenderSettings {
             backdrop_badge_size: BadgeSize::Medium,
             backdrop_position: default_backdrop_position(),
             backdrop_badge_direction: default_backdrop_badge_direction(),
+            episode_ratings_enabled: true,
             episode_ratings_limit: default_episode_ratings_limit(),
             episode_badge_style: default_episode_badge_style(),
             episode_label_style: default_label_style(),
@@ -1820,6 +1859,10 @@ pub fn parse_global_render_settings(globals: &HashMap<String, String>) -> Render
             .get("textless")
             .map(|v| v == "true")
             .unwrap_or(defaults.textless),
+        ratings_enabled: globals
+            .get("ratings_enabled")
+            .map(|v| v != "false")
+            .unwrap_or(defaults.ratings_enabled),
         ratings_limit: globals
             .get("ratings_limit")
             .and_then(|v| v.parse().ok())
@@ -1827,10 +1870,18 @@ pub fn parse_global_render_settings(globals: &HashMap<String, String>) -> Render
         ratings_order: arc_or("ratings_order", defaults.ratings_order),
         is_default: true,
         poster_position: global_or(globals, "poster_position", BadgePosition::parse, defaults.poster_position),
+        logo_ratings_enabled: globals
+            .get("logo_ratings_enabled")
+            .map(|v| v != "false")
+            .unwrap_or(defaults.logo_ratings_enabled),
         logo_ratings_limit: globals
             .get("logo_ratings_limit")
             .and_then(|v| v.parse().ok())
             .unwrap_or(defaults.logo_ratings_limit),
+        backdrop_ratings_enabled: globals
+            .get("backdrop_ratings_enabled")
+            .map(|v| v != "false")
+            .unwrap_or(defaults.backdrop_ratings_enabled),
         backdrop_ratings_limit: globals
             .get("backdrop_ratings_limit")
             .and_then(|v| v.parse().ok())
@@ -1847,6 +1898,10 @@ pub fn parse_global_render_settings(globals: &HashMap<String, String>) -> Render
         backdrop_badge_size: global_or(globals, "backdrop_badge_size", BadgeSize::parse, defaults.backdrop_badge_size),
         backdrop_position: global_or(globals, "backdrop_position", BadgePosition::parse, defaults.backdrop_position),
         backdrop_badge_direction: global_or(globals, "backdrop_badge_direction", BadgeDirection::parse, defaults.backdrop_badge_direction),
+        episode_ratings_enabled: globals
+            .get("episode_ratings_enabled")
+            .map(|v| v != "false")
+            .unwrap_or(defaults.episode_ratings_enabled),
         episode_ratings_limit: globals
             .get("episode_ratings_limit")
             .and_then(|v| v.parse().ok())
@@ -1875,11 +1930,14 @@ pub async fn get_effective_render_settings(
                 image_source: parse_setting_or_default(&s.image_source, "image_source", ImageSource::parse, ImageSource::Tmdb),
                 lang: Arc::from(s.lang.as_str()),
                 textless: s.textless,
+                ratings_enabled: s.ratings_enabled,
                 ratings_limit: s.ratings_limit,
                 ratings_order: Arc::from(s.ratings_order.as_str()),
                 is_default: false,
                 poster_position: parse_setting_or_default(&s.poster_position, "poster_position", BadgePosition::parse, BadgePosition::BottomCenter),
+                logo_ratings_enabled: s.logo_ratings_enabled,
                 logo_ratings_limit: s.logo_ratings_limit,
+                backdrop_ratings_enabled: s.backdrop_ratings_enabled,
                 backdrop_ratings_limit: s.backdrop_ratings_limit,
                 poster_badge_style: parse_setting_or_default(&s.poster_badge_style, "poster_badge_style", BadgeStyle::parse, BadgeStyle::Default),
                 logo_badge_style: parse_setting_or_default(&s.logo_badge_style, "logo_badge_style", BadgeStyle::parse, BadgeStyle::Vertical),
@@ -1893,6 +1951,7 @@ pub async fn get_effective_render_settings(
                 backdrop_badge_size: parse_setting_or_default(&s.backdrop_badge_size, "backdrop_badge_size", BadgeSize::parse, BadgeSize::Medium),
                 backdrop_position: parse_setting_or_default(&s.backdrop_position, "backdrop_position", BadgePosition::parse, default_backdrop_position()),
                 backdrop_badge_direction: parse_setting_or_default(&s.backdrop_badge_direction, "backdrop_badge_direction", BadgeDirection::parse, default_backdrop_badge_direction()),
+                episode_ratings_enabled: s.episode_ratings_enabled,
                 episode_ratings_limit: s.episode_ratings_limit,
                 episode_badge_style: parse_setting_or_default(&s.episode_badge_style, "episode_badge_style", BadgeStyle::parse, default_episode_badge_style()),
                 episode_label_style: parse_setting_or_default(&s.episode_label_style, "episode_label_style", LabelStyle::parse, LabelStyle::Official),

--- a/api/src/upgrade/mod.rs
+++ b/api/src/upgrade/mod.rs
@@ -1,5 +1,6 @@
 mod v001_backdrop_cache_keys;
 mod v002_backdrop_position_direction_cache;
+mod v003_ratings_enabled_flags;
 
 use sea_orm::{ConnectionTrait, DatabaseConnection};
 
@@ -22,6 +23,11 @@ pub async fn run(
 
     run_once(db, "v002_backdrop_position_direction_cache", || {
         v002_backdrop_position_direction_cache::run(db, cache_dir, external_cache_only)
+    })
+    .await?;
+
+    run_once(db, "v003_ratings_enabled_flags", || {
+        v003_ratings_enabled_flags::run(db, cache_dir, external_cache_only)
     })
     .await?;
 

--- a/api/src/upgrade/v003_ratings_enabled_flags.rs
+++ b/api/src/upgrade/v003_ratings_enabled_flags.rs
@@ -1,0 +1,54 @@
+use sea_orm::{ConnectionTrait, DatabaseConnection};
+
+use crate::error::AppError;
+
+/// Migrate existing rows that used `ratings_limit = 0` as a "disabled" sentinel.
+///
+/// Before this change, a limit of 0 meant ratings were disabled. Now a separate
+/// `ratings_enabled` boolean column carries that state, and the limit always
+/// holds a meaningful display value (≥ 1). This upgrade:
+///
+/// 1. Sets `*_ratings_enabled = 0` for any row whose limit was 0.
+/// 2. Resets those limits to their default values so the UI shows a sensible number.
+pub async fn run(
+    db: &DatabaseConnection,
+    _cache_dir: &str,
+    _external_cache_only: bool,
+) -> Result<(), AppError> {
+    let mut total = 0u64;
+
+    let result = db
+        .execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "UPDATE api_key_settings SET ratings_enabled = 0, ratings_limit = 3 WHERE ratings_limit = 0",
+        ))
+        .await?;
+    total += result.rows_affected();
+
+    let result = db
+        .execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "UPDATE api_key_settings SET logo_ratings_enabled = 0, logo_ratings_limit = 5 WHERE logo_ratings_limit = 0",
+        ))
+        .await?;
+    total += result.rows_affected();
+
+    let result = db
+        .execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "UPDATE api_key_settings SET backdrop_ratings_enabled = 0, backdrop_ratings_limit = 5 WHERE backdrop_ratings_limit = 0",
+        ))
+        .await?;
+    total += result.rows_affected();
+
+    let result = db
+        .execute(sea_orm::Statement::from_string(
+            sea_orm::DatabaseBackend::Sqlite,
+            "UPDATE api_key_settings SET episode_ratings_enabled = 0, episode_ratings_limit = 1 WHERE episode_ratings_limit = 0",
+        ))
+        .await?;
+    total += result.rows_affected();
+
+    tracing::info!(rows = total, "migrated ratings_limit=0 sentinel rows to ratings_enabled=false");
+    Ok(())
+}

--- a/web/src/components/RenderSettingsForm.vue
+++ b/web/src/components/RenderSettingsForm.vue
@@ -21,11 +21,14 @@ export interface RenderSettings {
   lang: string
   textless: boolean
   fanart_available: boolean
+  ratings_enabled: boolean
   ratings_limit: number
   ratings_order: string
   is_default?: boolean
   poster_position: string
+  logo_ratings_enabled: boolean
   logo_ratings_limit: number
+  backdrop_ratings_enabled: boolean
   backdrop_ratings_limit: number
   poster_badge_style: string
   logo_badge_style: string
@@ -39,6 +42,7 @@ export interface RenderSettings {
   backdrop_badge_size: string
   backdrop_position: string
   backdrop_badge_direction: string
+  episode_ratings_enabled: boolean
   episode_ratings_limit: number
   episode_badge_style: string
   episode_label_style: string
@@ -64,13 +68,13 @@ const editFanart = ref(props.settings.image_source === 'f')
 const editLang = ref(props.settings.lang || 'en')
 const editTextless = ref(props.settings.textless)
 const editSource = computed(() => editFanart.value ? 'f' : 't')
-const editRatingsEnabled = ref(props.settings.ratings_limit !== 0)
+const editRatingsEnabled = ref(props.settings.ratings_enabled ?? true)
 const editRatingsLimit = ref(props.settings.ratings_limit || 3)
 const editRatingsOrder = ref<string[]>(parseRatingsOrder(props.settings.ratings_order))
 const editPosterPosition = ref(props.settings.poster_position || 'bc')
-const editLogoRatingsEnabled = ref((props.settings.logo_ratings_limit ?? 3) !== 0)
+const editLogoRatingsEnabled = ref(props.settings.logo_ratings_enabled ?? true)
 const editLogoRatingsLimit = ref(props.settings.logo_ratings_limit || 3)
-const editBackdropRatingsEnabled = ref((props.settings.backdrop_ratings_limit ?? 3) !== 0)
+const editBackdropRatingsEnabled = ref(props.settings.backdrop_ratings_enabled ?? true)
 const editBackdropRatingsLimit = ref(props.settings.backdrop_ratings_limit || 3)
 const editPosterBadgeStyle = ref(props.settings.poster_badge_style || 'd')
 const editLogoBadgeStyle = ref(props.settings.logo_badge_style || 'v')
@@ -84,7 +88,7 @@ const editLogoBadgeSize = ref(props.settings.logo_badge_size || 'm')
 const editBackdropBadgeSize = ref(props.settings.backdrop_badge_size || 'm')
 const editBackdropPosition = ref(props.settings.backdrop_position || 'tr')
 const editBackdropBadgeDirection = ref(props.settings.backdrop_badge_direction || 'v')
-const editEpisodeRatingsEnabled = ref((props.settings.episode_ratings_limit ?? 1) !== 0)
+const editEpisodeRatingsEnabled = ref(props.settings.episode_ratings_enabled ?? true)
 const editEpisodeRatingsLimit = ref(props.settings.episode_ratings_limit || 1)
 const editEpisodeBadgeStyle = ref(props.settings.episode_badge_style || 'v')
 const editEpisodeLabelStyle = ref(props.settings.episode_label_style || 'o')
@@ -97,13 +101,13 @@ function applySettings(s: RenderSettings) {
   editFanart.value = s.image_source === 'f'
   editLang.value = s.lang || 'en'
   editTextless.value = s.textless
-  editRatingsEnabled.value = s.ratings_limit !== 0
-  if (s.ratings_limit !== 0) editRatingsLimit.value = s.ratings_limit
+  editRatingsEnabled.value = s.ratings_enabled ?? true
+  if (s.ratings_limit) editRatingsLimit.value = s.ratings_limit
   editRatingsOrder.value = parseRatingsOrder(s.ratings_order)
   editPosterPosition.value = s.poster_position || 'bc'
-  editLogoRatingsEnabled.value = (s.logo_ratings_limit ?? 3) !== 0
+  editLogoRatingsEnabled.value = s.logo_ratings_enabled ?? true
   if (s.logo_ratings_limit) editLogoRatingsLimit.value = s.logo_ratings_limit
-  editBackdropRatingsEnabled.value = (s.backdrop_ratings_limit ?? 3) !== 0
+  editBackdropRatingsEnabled.value = s.backdrop_ratings_enabled ?? true
   if (s.backdrop_ratings_limit) editBackdropRatingsLimit.value = s.backdrop_ratings_limit
   editPosterBadgeStyle.value = s.poster_badge_style || 'd'
   editLogoBadgeStyle.value = s.logo_badge_style || 'v'
@@ -117,7 +121,7 @@ function applySettings(s: RenderSettings) {
   editBackdropBadgeSize.value = s.backdrop_badge_size || 'm'
   editBackdropPosition.value = s.backdrop_position || 'tr'
   editBackdropBadgeDirection.value = s.backdrop_badge_direction || 'v'
-  editEpisodeRatingsEnabled.value = (s.episode_ratings_limit ?? 1) !== 0
+  editEpisodeRatingsEnabled.value = s.episode_ratings_enabled ?? true
   if (s.episode_ratings_limit) editEpisodeRatingsLimit.value = s.episode_ratings_limit
   editEpisodeBadgeStyle.value = s.episode_badge_style || 'v'
   editEpisodeLabelStyle.value = s.episode_label_style || 'o'
@@ -164,11 +168,14 @@ async function autoSave() {
       image_source: editSource.value,
       lang: editLang.value,
       textless: editTextless.value,
-      ratings_limit: editRatingsEnabled.value ? editRatingsLimit.value : 0,
+      ratings_enabled: editRatingsEnabled.value,
+      ratings_limit: editRatingsLimit.value,
       ratings_order: editRatingsOrder.value.join(','),
       poster_position: editPosterPosition.value,
-      logo_ratings_limit: editLogoRatingsEnabled.value ? editLogoRatingsLimit.value : 0,
-      backdrop_ratings_limit: editBackdropRatingsEnabled.value ? editBackdropRatingsLimit.value : 0,
+      logo_ratings_enabled: editLogoRatingsEnabled.value,
+      logo_ratings_limit: editLogoRatingsLimit.value,
+      backdrop_ratings_enabled: editBackdropRatingsEnabled.value,
+      backdrop_ratings_limit: editBackdropRatingsLimit.value,
       poster_badge_style: editPosterBadgeStyle.value,
       logo_badge_style: editLogoBadgeStyle.value,
       backdrop_badge_style: editBackdropBadgeStyle.value,
@@ -181,7 +188,8 @@ async function autoSave() {
       backdrop_badge_size: editBackdropBadgeSize.value,
       backdrop_position: editBackdropPosition.value,
       backdrop_badge_direction: editBackdropBadgeDirection.value,
-      episode_ratings_limit: editEpisodeRatingsEnabled.value ? editEpisodeRatingsLimit.value : 0,
+      episode_ratings_enabled: editEpisodeRatingsEnabled.value,
+      episode_ratings_limit: editEpisodeRatingsLimit.value,
       episode_badge_style: editEpisodeBadgeStyle.value,
       episode_label_style: editEpisodeLabelStyle.value,
       episode_badge_size: editEpisodeBadgeSize.value,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -68,10 +68,13 @@ export interface SaveSettingsPayload {
   image_source: string
   lang: string
   textless: boolean
+  ratings_enabled: boolean
   ratings_limit: number
   ratings_order: string
   poster_position: string
+  logo_ratings_enabled: boolean
   logo_ratings_limit: number
+  backdrop_ratings_enabled: boolean
   backdrop_ratings_limit: number
   poster_badge_style: string
   logo_badge_style: string
@@ -85,6 +88,7 @@ export interface SaveSettingsPayload {
   backdrop_badge_size: string
   backdrop_position: string
   backdrop_badge_direction: string
+  episode_ratings_enabled: boolean
   episode_ratings_limit: number
   episode_badge_style: string
   episode_label_style: string


### PR DESCRIPTION
Closes #25 

Two commits:

## **UI only** (6aa4538)
Replaces the "Max ratings" number input with a "Show ratings" checkbox toggle that disables the limit input when unchecked. Checkboxes are now aligned to the same grid as the selects above them with a separator, rather than stacked separately below. No DB write, toggling off while `ratings_limit = 0` would not persist across a refresh.

<details><summary>Screenshot</summary>
<img width="476" height="905" alt="image" src="https://github.com/user-attachments/assets/d668c51d-b962-47b1-ab50-ae0f09ed78f7" />
</details> 

## **DB schema** (431a0ff)
Adds dedicated `ratings_enabled` boolean columns (one per image type) so enabled state is stored independently of the limit value. The limit now always holds a meaningful value and is never `0`. A one-time migration (v003) converts any existing `ratings_limit = 0` rows to `ratings_enabled = false` with the limit reset to its type default.

## Notes

- The base poster ratings fields (`ratings_enabled`, `ratings_limit`, `ratings_order`) lack a `poster_` prefix unlike `logo_ratings_*`, `backdrop_ratings_*`, and `episode_ratings_*`. This is intentional, I assume they predate the other image types and were never prefixed. Worth revisiting in a future cleanup.
- The `?ratings_limit=0` URL query parameter override mentioned in the README is unaffected.
- Happy to revert to the UI only commit if a DB schema change isn't welcome yet.