### PR TITLE
ci: switch release build cache to ghcr registry backend

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
           file: Containerfile
           platforms: ${{ matrix.platform }}
           outputs: type=image,"name=ghcr.io/${{ steps.meta.outputs.image_name }},${{ secrets.DOCKERHUB_USERNAME }}/openposterdb",push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ matrix.platform }}
-          cache-to: type=gha,scope=${{ matrix.platform }},mode=max
+          cache-from: type=registry,ref=ghcr.io/${{ steps.meta.outputs.image_name }}-buildcache:${{ steps.meta.outputs.platform_pair }}
+          cache-to: type=registry,ref=ghcr.io/${{ steps.meta.outputs.image_name }}-buildcache:${{ steps.meta.outputs.platform_pair }},compression=zstd,mode=max
 
       - name: Export digest
         run: |


### PR DESCRIPTION
The release workflow was using `type=gha` as the cache backend for Docker layer caching. 

This has two problems:

#### The cache is write-only per release
- GitHub scopes Actions caches to the ref that created them, and tags can only read caches from the default branch, not from other tags. This means caches written under `refs/tags/v1.1.1` cannot be read by `refs/tags/v1.1.2`, any PR (not that it was), or any branch. Every release was writing ~800 MB of Docker layer blobs that nothing could ever read again.

#### It was crowding out the Rust cache
- This left the 10 GB quota constantly at capacity, meaning Rust caches from test jobs are at risk of eviction and may not survive between runs.

<hr>

#### Suggested change:
Switch to `type=registry` using GHCR as the cache backend, with separate tags per platform (`-buildcache:linux-amd64`, `-buildcache:linux-arm64`). The cache now lives in the container registry instead of the Actions cache, no size limit, no ref scoping, reusable across every release. The separate platform tags are necessary to prevent the two parallel build jobs from overwriting each other's cache. The tags should be automatically created by GHCR on the first run.

No secrets or repository configuration needed beyond the existing `packages: write` permission. And since its already logging into GHCR with the login-action, it should be able to create the new package that inherits the same permissions.