### PR TITLE
ci: skip tests on non-code changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,16 @@ name: Tests
 on:
   push:
     branches: [main]
+    paths:
+      - ".github/workflows/test.yml"
+      - "api/**"
+      - "web/**"
   pull_request:
     branches: [main]
+    paths:
+      - ".github/workflows/test.yml"
+      - "api/**"
+      - "web/**"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The test workflow currently runs on every push and pull request to main regardless of what changed. This means changes to workflow files, documentation, or anything else unrelated to the actual codebase trigger all three test jobs unnecessarily, including the E2E job which takes even longer than just the backend alone.

This adds path filters so tests only run when files in `api/**` or `web/**` change. Adding `.github/workflows/test.yml` to the filter ensures that if the workflow file itself is modified, it runs against the new version of itself to verify the change.