### PR TITLE
ci: replace BuildKit attestations with proper signed provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           context: .
           file: Containerfile
+          provenance: false
           platforms: ${{ matrix.platform }}
           outputs: type=image,"name=ghcr.io/${{ steps.meta.outputs.image_name }},${{ secrets.DOCKERHUB_USERNAME }}/openposterdb",push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.platform }}
@@ -69,6 +70,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
+      artifact-metadata: write
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -103,23 +107,55 @@ jobs:
           echo "image_name=$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Create and push GHCR manifest
+        id: ghcr_manifest
         working-directory: ${{ runner.temp }}/digests
         run: |
           GHCR_IMAGE="ghcr.io/${{ steps.meta.outputs.image_name }}"
-          docker buildx imagetools create \
+          if ! OUTPUT=$(docker buildx imagetools create \
             -t "$GHCR_IMAGE:${{ steps.meta.outputs.tag }}" \
             -t "$GHCR_IMAGE:${{ steps.meta.outputs.version }}" \
             -t "$GHCR_IMAGE:${{ steps.meta.outputs.major }}" \
             -t "$GHCR_IMAGE:latest" \
-            $(for f in *; do echo "$GHCR_IMAGE@$(cat "$f")"; done)
+            $(for f in *; do echo "$GHCR_IMAGE@$(cat "$f")"; done) 2>&1); then
+            echo "Manifest creation failed"
+            echo "${OUTPUT}"
+            exit 1
+          fi
+          echo "${OUTPUT}"
+          DIGEST_SHA="$(echo "${OUTPUT}" | grep -oE 'sha256:[a-f0-9]{64}' | tail -1)"
+          echo "digest=${DIGEST_SHA}" >> "${GITHUB_OUTPUT}"
 
       - name: Create and push Docker Hub manifest
+        id: dh_manifest
         working-directory: ${{ runner.temp }}/digests
         run: |
           DH_IMAGE="${{ secrets.DOCKERHUB_USERNAME }}/openposterdb"
-          docker buildx imagetools create \
+          if ! OUTPUT=$(docker buildx imagetools create \
             -t "$DH_IMAGE:${{ steps.meta.outputs.tag }}" \
             -t "$DH_IMAGE:${{ steps.meta.outputs.version }}" \
             -t "$DH_IMAGE:${{ steps.meta.outputs.major }}" \
             -t "$DH_IMAGE:latest" \
-            $(for f in *; do echo "$DH_IMAGE@$(cat "$f")"; done)
+            $(for f in *; do echo "$DH_IMAGE@$(cat "$f")"; done) 2>&1); then
+            echo "Manifest creation failed"
+            echo "${OUTPUT}"
+            exit 1
+          fi
+          echo "${OUTPUT}"
+          DIGEST_SHA="$(echo "${OUTPUT}" | grep -oE 'sha256:[a-f0-9]{64}' | tail -1)"
+          echo "digest=${DIGEST_SHA}" >> "${GITHUB_OUTPUT}"
+
+      - name: Attest GHCR image
+        if: steps.ghcr_manifest.outputs.digest != ''
+        uses: actions/attest@v4
+        with:
+          subject-name: ghcr.io/${{ steps.meta.outputs.image_name }}
+          subject-digest: ${{ steps.ghcr_manifest.outputs.digest }}
+          push-to-registry: true
+
+      - name: Attest Docker Hub image
+        if: steps.dh_manifest.outputs.digest != ''
+        uses: actions/attest@v4
+        with:
+          subject-name: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/openposterdb
+          subject-digest: ${{ steps.dh_manifest.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
The GHCR container page currently shows `unknown/unknown` entries alongside `linux/amd64` and `linux/arm64`. This is caused by BuildKit automatically embedding attestation metadata directly into the image manifest, which GHCR displays as an extra platform entry.

Inspecting the manifest confirms these are BuildKit embedded attestations, each has a `vnd.docker.reference.type: attestation-manifest` annotation referencing its respective platform image:

```bash
$ docker buildx imagetools inspect ghcr.io/pnrxa/openposterdb:latest

Manifests: 
  Name:        ghcr.io/pnrxa/openposterdb:latest@sha256:f9ffa3a13919dcba90a3e1edc3df3ebfcc8ebb16bacb4fab6d6e4ef658fe5f2d
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/amd64
               
  Name:        ghcr.io/pnrxa/openposterdb:latest@sha256:ce0ddfe5c1bb96099f77f87f786c69595f6f36194efa0dee66c202f140507645
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:f9ffa3a13919dcba90a3e1edc3df3ebfcc8ebb16bacb4fab6d6e4ef658fe5f2d
    vnd.docker.reference.type:   attestation-manifest
               
  Name:        ghcr.io/pnrxa/openposterdb:latest@sha256:6a779932e07bf430d21fe8f78268c4465a8168995331f4033f4f7b3b15771318
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/arm64
               
  Name:        ghcr.io/pnrxa/openposterdb:latest@sha256:503461cba08afa6a46a51aa9ff98c6b229fad1396412e16810daf094f8e2cf83
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations: 
    vnd.docker.reference.digest: sha256:6a779932e07bf430d21fe8f78268c4465a8168995331f4033f4f7b3b15771318
    vnd.docker.reference.type:   attestation-manifest

```

<hr>

This PR fixes that by:
- Adding `provenance: false` to the build step to disable BuildKit's automatic attestation embedding
- Capturing the merged manifest digest from each imagetools create call
- Attaching proper signed provenance attestations to both the GHCR and Docker Hub images using `actions/attest` via Sigstore/OIDC