### PR TITLE
ci: cancel redundant test runs on PR updates

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Tests
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Adds concurrency control to the test workflow so that pushing a new commit to a PR cancels any still running tests from the previous commit. Runs on main are never cancelled.