### PR TITLE
feat: add DISABLE_PUBLIC_PAGES to hide public routes on private instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ See [docker-compose.yml](docker-compose.yml) for the full compose configuration.
 | `ENABLE_CDN_REDIRECTS` | `false` | Enable content-addressed CDN redirects (see [CDN Caching](#cdn-caching)) |
 | `EXTERNAL_CACHE_ONLY` | `false` | Skip image file writes to disk; rely on a CDN for caching. SQLite metadata is still written (see [External Cache Only](#external-cache-only)) |
 | `FREE_KEY_ENABLED` | — | Force-enable (`true`) or force-disable (`false`) the free API key, overriding the admin UI toggle. When set, the UI toggle is locked. Omit to let admins control it from the settings page |
+| `DISABLE_PUBLIC_PAGES` | `false` | Hide the landing page, docs, legal, and all unauthenticated routes, redirecting visitors to the login page instead. All pages remain accessible to authenticated users. Useful for private self-hosted instances that aren't intended to be publicly accessible |
 
 ## Cache Architecture
 

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -19,6 +19,7 @@ pub struct Config {
     pub enable_cdn_redirects: bool,
     pub external_cache_only: bool,
     pub free_key_enabled: Option<bool>,
+    pub disable_public_pages: bool,
 }
 
 impl std::fmt::Debug for Config {
@@ -41,6 +42,7 @@ impl std::fmt::Debug for Config {
             .field("enable_cdn_redirects", &self.enable_cdn_redirects)
             .field("external_cache_only", &self.external_cache_only)
             .field("free_key_enabled", &self.free_key_enabled)
+            .field("disable_public_pages", &self.disable_public_pages)
             .finish()
     }
 }
@@ -86,6 +88,9 @@ impl Config {
             free_key_enabled: env::var("FREE_KEY_ENABLED")
                 .ok()
                 .map(|v| v == "true" || v == "1"),
+            disable_public_pages: env::var("DISABLE_PUBLIC_PAGES")
+                .map(|v| v == "true" || v == "1")
+                .unwrap_or(false),
         };
 
         if config.omdb_api_key.is_none() && config.mdblist_api_key.is_none() {
@@ -125,6 +130,7 @@ mod tests {
             "ENABLE_CDN_REDIRECTS",
             "EXTERNAL_CACHE_ONLY",
             "FREE_KEY_ENABLED",
+            "DISABLE_PUBLIC_PAGES",
         ] {
             unsafe { env::remove_var(key) };
         }
@@ -225,10 +231,12 @@ mod tests {
         unsafe { env::set_var("OMDB_API_KEY", "omdb_test") };
         unsafe { env::set_var("ENABLE_CDN_REDIRECTS", "true") };
         unsafe { env::set_var("EXTERNAL_CACHE_ONLY", "1") };
+        unsafe { env::set_var("DISABLE_PUBLIC_PAGES", "true") };
 
         let cfg = Config::from_env();
         assert!(cfg.enable_cdn_redirects);
         assert!(cfg.external_cache_only);
+        assert!(cfg.disable_public_pages);
     }
 
     #[test]
@@ -241,6 +249,7 @@ mod tests {
         let cfg = Config::from_env();
         assert!(!cfg.enable_cdn_redirects);
         assert!(!cfg.external_cache_only);
+        assert!(!cfg.disable_public_pages);
     }
 
     #[test]

--- a/api/src/handlers/auth.rs
+++ b/api/src/handlers/auth.rs
@@ -178,6 +178,7 @@ pub async fn auth_status(
     Ok(Json(json!({
         "setup_required": count == 0,
         "free_api_key_enabled": free_api_key_enabled,
+        "disable_public_pages": state.config.disable_public_pages,
     })))
 }
 

--- a/api/src/handlers/middleware.rs
+++ b/api/src/handlers/middleware.rs
@@ -73,3 +73,30 @@ pub async fn require_api_key_auth(
 
     Ok(next.run(req).await)
 }
+
+/// Accepts either a valid admin JWT or a valid API key JWT.
+/// Used to gate endpoints that any authenticated session can access.
+pub async fn require_any_auth(
+    State(state): State<Arc<AppState>>,
+    req: Request<Body>,
+    next: Next,
+) -> Result<Response, StatusCode> {
+    let token = req
+        .headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    let key = DecodingKey::from_secret(&state.jwt_secret);
+    let validation = Validation::new(jsonwebtoken::Algorithm::HS256);
+
+    let is_valid = decode::<Claims>(token, &key, &validation).is_ok()
+        || decode::<ApiKeyClaims>(token, &key, &validation).is_ok();
+
+    if is_valid {
+        Ok(next.run(req).await)
+    } else {
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}

--- a/api/src/routes/app.rs
+++ b/api/src/routes/app.rs
@@ -106,22 +106,33 @@ pub fn build_app(state: Arc<AppState>) -> Router {
         ),
     );
 
+    let openapi_route = Router::new().route(
+        "/api/openapi.json",
+        axum::routing::get(|| async {
+            (
+                [
+                    (header::CONTENT_TYPE, "application/json"),
+                    (header::CACHE_CONTROL, "public, max-age=86400"),
+                ],
+                OPENAPI_JSON.as_str(),
+            )
+        }),
+    );
+
+    let openapi_route = if state.config.disable_public_pages {
+        openapi_route.layer(middleware::from_fn_with_state(
+            state.clone(),
+            handlers::middleware::require_any_auth,
+        ))
+    } else {
+        openapi_route
+    };
+
     let compressed_routes = Router::new()
         .merge(super::auth::auth_routes())
         .merge(admin_routes)
         .merge(key_self_routes)
-        .route(
-            "/api/openapi.json",
-            axum::routing::get(|| async {
-                (
-                    [
-                        (header::CONTENT_TYPE, "application/json"),
-                        (header::CACHE_CONTROL, "public, max-age=86400"),
-                    ],
-                    OPENAPI_JSON.as_str(),
-                )
-            }),
-        )
+        .merge(openapi_route)
         .layer(CompressionLayer::new());
 
     let mut app = Router::new()

--- a/api/tests/common/mod.rs
+++ b/api/tests/common/mod.rs
@@ -123,6 +123,7 @@ async fn _setup_test_app(cors_origin: Option<String>, secure_cookies: bool, enab
             enable_cdn_redirects,
             external_cache_only,
             free_key_enabled,
+            disable_public_pages: false,
         },
         tmdb: TmdbClient::new("test".into(), http.clone()),
         omdb: None,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       ADMIN_PASSWORD: ${ADMIN_PASSWORD:-}
       ENABLE_CDN_REDIRECTS: ${ENABLE_CDN_REDIRECTS:-false}
       EXTERNAL_CACHE_ONLY: ${EXTERNAL_CACHE_ONLY:-false}
+      DISABLE_PUBLIC_PAGES: ${DISABLE_PUBLIC_PAGES:-false}
     volumes:
       - openposterdb-data:/data
     restart: unless-stopped

--- a/web/src/__tests__/router/index.spec.ts
+++ b/web/src/__tests__/router/index.spec.ts
@@ -40,6 +40,8 @@ function makeRouter() {
       },
       { path: '/login', name: 'login', component: { template: '<div>Login</div>' } },
       { path: '/setup', name: 'setup', component: { template: '<div>Setup</div>' } },
+      { path: '/docs', name: 'docs', component: { template: '<div>Docs</div>' } },
+      { path: '/legal', name: 'legal', component: { template: '<div>Legal</div>' } },
     ],
   })
   router.beforeEach(routeGuard)
@@ -153,5 +155,59 @@ describe('router', () => {
     await router.isReady()
 
     expect(router.currentRoute.value.name).toBe('episodes')
+  })
+
+  it('unauthenticated user visiting /docs with disablePublicPages is redirected to login', async () => {
+    const router = makeRouter()
+    const auth = useAuthStore()
+    auth.disablePublicPages = true
+
+    await router.push('/docs')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('login')
+  })
+
+  it('unauthenticated user visiting /legal with disablePublicPages is redirected to login', async () => {
+    const router = makeRouter()
+    const auth = useAuthStore()
+    auth.disablePublicPages = true
+
+    await router.push('/legal')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('login')
+  })
+
+  it('unauthenticated user visiting / with disablePublicPages is redirected to login', async () => {
+    const router = makeRouter()
+    const auth = useAuthStore()
+    auth.disablePublicPages = true
+
+    await router.push('/')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('login')
+  })
+
+  it('authenticated admin visiting /docs with disablePublicPages can access it', async () => {
+    const router = makeRouter()
+    const auth = useAuthStore()
+    auth.token = 'valid-token'
+    auth.disablePublicPages = true
+
+    await router.push('/docs')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('docs')
+  })
+
+  it('unauthenticated user visiting /docs without disablePublicPages can access it', async () => {
+    const router = makeRouter()
+
+    await router.push('/docs')
+    await router.isReady()
+
+    expect(router.currentRoute.value.name).toBe('docs')
   })
 })

--- a/web/src/__tests__/stores/auth.spec.ts
+++ b/web/src/__tests__/stores/auth.spec.ts
@@ -335,4 +335,29 @@ describe('auth store', () => {
 
     expect(auth.freeApiKeyEnabled).toBe(false)
   })
+
+  it('disablePublicPages defaults to false', () => {
+    const auth = useAuthStore()
+    expect(auth.disablePublicPages).toBe(false)
+  })
+
+  it('checkSetupRequired populates disablePublicPages from response', async () => {
+    const fetchMock = mockFetchSuccess({ setup_required: false, disable_public_pages: true })
+    vi.stubGlobal('fetch', fetchMock)
+    const auth = useAuthStore()
+
+    await auth.checkSetupRequired()
+
+    expect(auth.disablePublicPages).toBe(true)
+  })
+
+  it('checkSetupRequired sets disablePublicPages false when not in response', async () => {
+    const fetchMock = mockFetchSuccess({ setup_required: false })
+    vi.stubGlobal('fetch', fetchMock)
+    const auth = useAuthStore()
+
+    await auth.checkSetupRequired()
+
+    expect(auth.disablePublicPages).toBe(false)
+  })
 })

--- a/web/src/__tests__/views/DocsView.spec.ts
+++ b/web/src/__tests__/views/DocsView.spec.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest'
-import { shallowMount } from '@vue/test-utils'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { shallowMount, flushPromises } from '@vue/test-utils'
 
 vi.mock('@scalar/api-reference', () => ({
   ApiReference: {
@@ -11,9 +11,33 @@ vi.mock('@scalar/api-reference', () => ({
 
 vi.mock('@scalar/api-reference/style.css', () => ({}))
 
+const mockAuthStore = {
+  token: null as string | null,
+  apiKeyToken: null as string | null,
+}
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => mockAuthStore,
+}))
+
 import DocsView from '@/views/DocsView.vue'
 
+const fakeSpec = { openapi: '3.1.0', info: { title: 'Test' } }
+
+function mockFetch(ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    json: () => Promise.resolve(fakeSpec),
+  })
+}
+
 describe('DocsView', () => {
+  beforeEach(() => {
+    mockAuthStore.token = null
+    mockAuthStore.apiKeyToken = null
+    vi.restoreAllMocks()
+  })
+
   function mountView() {
     return shallowMount(DocsView, {
       global: {
@@ -29,20 +53,64 @@ describe('DocsView', () => {
   }
 
   it('renders topbar with OpenPosterDB text and API Reference subtitle', () => {
+    vi.stubGlobal('fetch', mockFetch())
     const wrapper = mountView()
     expect(wrapper.text()).toContain('OpenPosterDB')
     expect(wrapper.text()).toContain('API Reference')
   })
 
-  it('renders ApiReference component with correct config', () => {
+  it('renders ApiReference component after spec loads', async () => {
+    vi.stubGlobal('fetch', mockFetch())
     const wrapper = mountView()
+    await flushPromises()
+
     const apiRef = wrapper.findComponent({ name: 'ApiReference' })
     expect(apiRef.exists()).toBe(true)
     expect(apiRef.props('configuration')).toEqual(
       expect.objectContaining({
-        url: '/api/openapi.json',
+        content: fakeSpec,
         hideClientButton: true,
       }),
     )
+  })
+
+  it('does not render ApiReference when spec fetch fails', async () => {
+    vi.stubGlobal('fetch', mockFetch(false))
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'ApiReference' }).exists()).toBe(false)
+  })
+
+  it('includes Authorization header when admin token is set', async () => {
+    mockAuthStore.token = 'admin-jwt'
+    const fetchMock = mockFetch()
+    vi.stubGlobal('fetch', fetchMock)
+    mountView()
+    await flushPromises()
+
+    const [, options] = fetchMock.mock.calls[0]
+    expect(options.headers['Authorization']).toBe('Bearer admin-jwt')
+  })
+
+  it('includes Authorization header when API key token is set', async () => {
+    mockAuthStore.apiKeyToken = 'key-jwt'
+    const fetchMock = mockFetch()
+    vi.stubGlobal('fetch', fetchMock)
+    mountView()
+    await flushPromises()
+
+    const [, options] = fetchMock.mock.calls[0]
+    expect(options.headers['Authorization']).toBe('Bearer key-jwt')
+  })
+
+  it('omits Authorization header when unauthenticated', async () => {
+    const fetchMock = mockFetch()
+    vi.stubGlobal('fetch', fetchMock)
+    mountView()
+    await flushPromises()
+
+    const [, options] = fetchMock.mock.calls[0]
+    expect(options.headers['Authorization']).toBeUndefined()
   })
 })

--- a/web/src/__tests__/views/LoginView.spec.ts
+++ b/web/src/__tests__/views/LoginView.spec.ts
@@ -14,6 +14,7 @@ const mockAuthStore = {
   loginWithApiKey: vi.fn(),
   isAuthenticated: false,
   freeApiKeyEnabled: false,
+  disablePublicPages: false,
 }
 
 vi.mock('vue-router', () => ({
@@ -50,6 +51,7 @@ describe('LoginView', () => {
     mockAuthStore.login.mockReset()
     mockAuthStore.loginWithApiKey.mockReset()
     mockAuthStore.freeApiKeyEnabled = false
+    mockAuthStore.disablePublicPages = false
   })
 
   it('renders admin login form by default', async () => {
@@ -151,6 +153,22 @@ describe('LoginView', () => {
 
     expect(wrapper.text()).not.toContain('Free API Key Available')
     expect(wrapper.text()).not.toContain('t0-free-rpdb')
+  })
+
+  it('shows back to home link when disablePublicPages is false', async () => {
+    mockAuthStore.disablePublicPages = false
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).toContain('Back to home')
+  })
+
+  it('hides back to home link when disablePublicPages is true', async () => {
+    mockAuthStore.disablePublicPages = true
+    const wrapper = mountView()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('Back to home')
   })
 
   it('toggles back to admin mode from apikey mode', async () => {

--- a/web/src/layouts/DashboardLayout.vue
+++ b/web/src/layouts/DashboardLayout.vue
@@ -6,19 +6,29 @@ import {
   SidebarTrigger,
 } from '@/components/ui/sidebar'
 import { Separator } from '@/components/ui/separator'
+import { Button } from '@/components/ui/button'
+import { BookOpen } from 'lucide-vue-next'
 import AppSidebar from '@/components/AppSidebar.vue'
+import { useAuthStore } from '@/stores/auth'
 
 const route = useRoute()
+const auth = useAuthStore()
 </script>
 
 <template>
   <SidebarProvider>
     <AppSidebar />
     <SidebarInset>
-      <header class="flex h-12 shrink-0 items-center gap-2 border-b px-4">
+      <header class="flex h-12 shrink-0 items-center gap-2 border-b px-4 pr-6">
         <SidebarTrigger class="-ml-1" />
         <Separator orientation="vertical" class="mr-2 !h-4" />
         <span class="text-sm font-medium">{{ route.meta.title || route.name }}</span>
+        <Button v-if="auth.disablePublicPages" as-child variant="outline" size="sm" class="ml-auto">
+          <router-link to="/docs">
+            <BookOpen class="h-4 w-4" />
+            API Docs
+          </router-link>
+        </Button>
       </header>
       <main class="flex-1 p-6">
         <RouterView />

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -7,7 +7,7 @@ export async function routeGuard(to: RouteLocationNormalized) {
   // Only check setup status when navigating to setup or login (avoids an API
   // call on every navigation). The result is cached in the auth store after the
   // first successful call.
-  if (to.name === 'setup' || to.name === 'login' || to.name === 'landing' || to.name === 'dashboard' || to.name === 'not-found') {
+  if (to.name === 'setup' || to.name === 'login' || to.name === 'landing' || to.name === 'dashboard' || to.name === 'not-found' || to.name === 'docs' || to.name === 'legal') {
     try {
       const setupRequired = await auth.checkSetupRequired()
       if (setupRequired && to.name !== 'setup') {
@@ -19,6 +19,14 @@ export async function routeGuard(to: RouteLocationNormalized) {
       }
     } catch {
       // If we can't check, continue
+    }
+  }
+
+  // Gate all public pages when DISABLE_PUBLIC_PAGES is set
+  if (auth.disablePublicPages && !auth.isAuthenticated) {
+    const publicPages = ['landing', 'legal', 'docs', 'not-found']
+    if (publicPages.includes(to.name as string)) {
+      return { name: 'login' }
     }
   }
 

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -6,6 +6,7 @@ export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem('token'))
   const setupRequired = ref<boolean | null>(null)
   const freeApiKeyEnabled = ref(false)
+  const disablePublicPages = ref(false)
 
   // API key session state (sessionStorage so it clears on tab close)
   const apiKeyToken = ref<string | null>(sessionStorage.getItem('apiKeyToken'))
@@ -32,6 +33,7 @@ export const useAuthStore = defineStore('auth', () => {
     const data = await res.json()
     setupRequired.value = data.setup_required
     freeApiKeyEnabled.value = !!data.free_api_key_enabled
+    disablePublicPages.value = !!data.disable_public_pages
     return data.setup_required
   }
 
@@ -91,6 +93,7 @@ export const useAuthStore = defineStore('auth', () => {
     isApiKeySession,
     setupRequired,
     freeApiKeyEnabled,
+    disablePublicPages,
     checkSetupRequired,
     setup,
     login,

--- a/web/src/views/DocsView.vue
+++ b/web/src/views/DocsView.vue
@@ -3,13 +3,27 @@ import { ref, onMounted } from "vue";
 import { ApiReference } from "@scalar/api-reference";
 import "@scalar/api-reference/style.css";
 import { ArrowLeft } from "lucide-vue-next";
+import { useAuthStore } from "@/stores/auth";
 
+const auth = useAuthStore();
 const topbar = ref<HTMLElement>();
 const headerHeight = ref("0px");
+const spec = ref<unknown>(null);
 
-onMounted(() => {
+onMounted(async () => {
   if (topbar.value) {
     headerHeight.value = `${topbar.value.offsetHeight}px`;
+  }
+
+  const headers: Record<string, string> = {};
+  const token = auth.token ?? auth.apiKeyToken;
+  if (token) {
+    headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  const res = await fetch("/api/openapi.json", { headers });
+  if (res.ok) {
+    spec.value = await res.json();
   }
 });
 </script>
@@ -23,8 +37,8 @@ onMounted(() => {
       </router-link>
       <span class="docs-subtitle">API Reference</span>
     </header>
-    <ApiReference :configuration="{
-      url: '/api/openapi.json',
+    <ApiReference v-if="spec" :configuration="{
+      content: spec,
       hideClientButton: true,
       showDeveloperTools: 'never',
       mcp: { disabled: true },

--- a/web/src/views/KeySettingsView.vue
+++ b/web/src/views/KeySettingsView.vue
@@ -6,6 +6,7 @@ import { selfApi, type SaveSettingsPayload } from '@/lib/api'
 import RenderSettingsForm from '@/components/RenderSettingsForm.vue'
 import type { RenderSettings } from '@/components/RenderSettingsForm.vue'
 import { Button } from '@/components/ui/button'
+import { BookOpen } from 'lucide-vue-next'
 
 const auth = useAuthStore()
 const router = useRouter()
@@ -85,6 +86,12 @@ function handleLogout() {
             <span class="font-mono">({{ keyPrefix }}...)</span>
           </p>
         </div>
+        <Button v-if="auth.disablePublicPages" as-child variant="outline" size="sm">
+          <router-link to="/docs">
+            <BookOpen class="h-4 w-4" />
+            API Docs
+          </router-link>
+        </Button>
         <Button variant="outline" size="sm" @click="handleLogout">Logout</Button>
       </div>
 

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -122,7 +122,7 @@ function toggleMode() {
         </button>
       </p>
 
-      <p class="text-center text-sm text-muted-foreground">
+      <p v-if="!auth.disablePublicPages" class="text-center text-sm text-muted-foreground">
         <router-link to="/" class="underline hover:text-foreground">&larr; Back to home</router-link>
       </p>
 


### PR DESCRIPTION
Adds a `DISABLE_PUBLIC_PAGES` environment variable for self-hosted instances that aren't intended to be publicly accessible.

When enabled, unauthenticated visitors are redirected to the login page instead of being able to view the landing page, API docs, and legal pages. All routes remain fully accessible to authenticated users (admin and API key sessions).

Changes:
 - New `DISABLE_PUBLIC_PAGES` env var (default false) read at startup and exposed via `/api/auth/status`
 - Frontend router guard redirects unauthenticated users away from `/`, `/docs`, `/legal`, and unmatched routes when the flag is set
 - `/api/openapi.json` requires a valid JWT (admin or API key) when the flag is set, preventing direct spec access
 - API Docs link surfaced in the admin dashboard header and key-settings page for authenticated users when the flag is set (since the landing page link is no longer visible, see UI screenshots below)
 - "Back to home" link hidden on the login page when the flag is set
 - `docker-compose.yml` and `README.md` updated with the new variable
 - Added some relevant test cases
 
<hr>

<details><summary>UI Changes</summary>

<ul><li>
<p>"Back to home" hidden when DISABLE_PUBLIC_PAGES is enabled</p>
<details><summary>For admin login</summary>
<img width="618" height="434" alt="image" src="https://github.com/user-attachments/assets/00401b46-1e12-4d80-9f52-622c2a7aa235" />
</details>

<details><summary>For API key login</summary>
<img width="520" height="314" alt="image" src="https://github.com/user-attachments/assets/477ea260-583f-42ab-8027-05ea8f86be23" />
</details>
</li></ul>

<ul><li>
<p>API Docs embedding</p>

<details><summary>Into DashboardLayout</summary>
<img width="2559" height="527" alt="image" src="https://github.com/user-attachments/assets/867cfdc0-8317-4dbd-b8a8-6d030b3261ff" />
</details>

<details><summary>Into KeySettingsView</summary>
<ul><li>
<p>Note: button maybe could be shifted further right? I feel like this page should be made into multiple columns anyway.</p>
</li></ul>

<img width="465" height="724" alt="image" src="https://github.com/user-attachments/assets/2f8f5e79-73ea-4a40-bb95-cd6eb92da889" />

</details>
</li></ul>
</details>