### PR TITLE
fix: resolve nested test file discovery for vitest and tsconfig

### DIFF
--- a/web/eslint.config.ts
+++ b/web/eslint.config.ts
@@ -29,7 +29,7 @@ export default defineConfigWithVueTs(
 
   {
     ...pluginVitest.configs.recommended,
-    files: ['src/**/__tests__/*'],
+    files: ['src/**/__tests__/**/*']
   },
 
   ...pluginOxlint.buildFromOxlintConfigFile('.oxlintrc.json'),

--- a/web/tsconfig.vitest.json
+++ b/web/tsconfig.vitest.json
@@ -3,7 +3,7 @@
 
   // Override to include only test files and clear exclusions.
   // Application code imported in tests is automatically included via module resolution.
-  "include": ["src/**/__tests__/*", "env.d.ts"],
+  "include": ["src/**/__tests__/**/*", "env.d.ts"],
   "exclude": [],
 
   "compilerOptions": {


### PR DESCRIPTION
Fix glob patterns in `tsconfig.vitest.json` and `eslint.config.ts` to use `**/*` instead of `*`, enabling discovery of test files in nested `__tests__` subdirectories.