### PR TITLE
ci: drop BuildKit attestation manifests to fix unknown/unknown arches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,11 @@ jobs:
           context: .
           file: Containerfile
           platforms: ${{ matrix.platform }}
+          # Disable BuildKit's automatic attestation manifests. These embed an
+          # extra image-index entry per platform that registries (e.g. GHCR)
+          # surface as bogus `unknown/unknown` architectures.
+          provenance: false
+          sbom: false
           outputs: type=image,"name=ghcr.io/${{ steps.meta.outputs.image_name }},${{ secrets.DOCKERHUB_USERNAME }}/openposterdb",push-by-digest=true,name-canonical=true,push=true
           cache-from: type=registry,ref=ghcr.io/${{ steps.meta.outputs.image_name }}-buildcache:${{ steps.meta.outputs.platform_pair }}
           cache-to: type=registry,ref=ghcr.io/${{ steps.meta.outputs.image_name }}-buildcache:${{ steps.meta.outputs.platform_pair }},compression=zstd,mode=max


### PR DESCRIPTION
## Problem

The GHCR (and Docker Hub) container pages show bogus `unknown/unknown` entries alongside `linux/amd64` and `linux/arm64`:

```
$ docker buildx imagetools inspect ghcr.io/pnrxa/openposterdb:latest
  Platform:    linux/amd64
  Platform:    unknown/unknown   <- attestation manifest
    vnd.docker.reference.type:   attestation-manifest
  Platform:    linux/arm64
  Platform:    unknown/unknown   <- attestation manifest
    vnd.docker.reference.type:   attestation-manifest
```

These extra entries are BuildKit's automatic provenance/SBOM **attestation manifests**, which it embeds as additional image-index entries (one per platform). Registries surface them as `unknown/unknown` "architectures".

## Fix

Set `provenance: false` and `sbom: false` on the `build-push-action` step so BuildKit stops embedding the attestation manifests. Only the real platform manifests are published, and the `unknown/unknown` entries disappear.

```yaml
      - uses: docker/build-push-action@v6
        with:
          ...
          provenance: false
          sbom: false
```

One line of intent, no extra build steps, no new permissions.

## Why not #31

This supersedes #31, which I don't think works as written:

- It uses `actions/attest@v4` (the **generic** attestation action) with only `subject-name`/`subject-digest`/`push-to-registry`. That action **requires** `predicate-type` and `predicate` inputs, so those steps would fail at runtime. Build provenance needs `actions/attest-build-provenance`, not the generic action.
- It declares `artifact-metadata: write`, which is not a valid GitHub Actions permission scope.
- It scrapes the final manifest digest out of `docker buildx imagetools create` stdout with `grep ... | tail -1`, which is unreliable — it can pick up a source platform digest instead of the pushed index digest.
- Re-pushing attestations to the registry can itself reintroduce extra untagged manifest entries — the very thing we're trying to remove.

`provenance: false` is the minimal, direct fix for the reported problem. If first-class signed supply-chain attestations are wanted later, that can be added deliberately as a separate change using `actions/attest-build-provenance` with the index digest obtained reliably (e.g. via `imagetools inspect --format`).
