### PR TITLE
feat: reflect server defaults in the free-key "Try it out" form

### DIFF
--- a/api/src/handlers/image.rs
+++ b/api/src/handlers/image.rs
@@ -2,7 +2,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::{header, StatusCode};
 use axum::response::{IntoResponse, Response};
 use bytes::Bytes;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 use crate::cache;
@@ -140,6 +140,91 @@ async fn resolve_free_settings(
             tracing::warn!(error = %e, "failed to load global settings, using defaults");
             Arc::new(db::RenderSettings::default())
         }))
+}
+
+/// Public, read-only view of the global default render settings the free API
+/// key serves with. Mirrors the per-type fields the "Try it out" UI needs so it
+/// can show the operator's actual configuration instead of hardcoded frontend
+/// defaults. This is a strict subset of the admin `GlobalSettingsResponse` —
+/// it deliberately omits operational flags (`fanart_available`,
+/// `free_api_key_locked`) so the public endpoint can't leak them.
+#[derive(Serialize)]
+pub struct FreeKeySettingsResponse {
+    pub image_source: ImageSource,
+    pub lang: String,
+    pub textless: bool,
+    pub ratings_limit: i32,
+    pub ratings_order: String,
+    pub ratings_exclude: String,
+    pub poster_position: BadgePosition,
+    pub logo_ratings_limit: i32,
+    pub backdrop_ratings_limit: i32,
+    pub poster_badge_style: BadgeStyle,
+    pub logo_badge_style: BadgeStyle,
+    pub backdrop_badge_style: BadgeStyle,
+    pub poster_label_style: LabelStyle,
+    pub logo_label_style: LabelStyle,
+    pub backdrop_label_style: LabelStyle,
+    pub poster_badge_direction: BadgeDirection,
+    pub poster_badge_size: BadgeSize,
+    pub logo_badge_size: BadgeSize,
+    pub backdrop_badge_size: BadgeSize,
+    pub backdrop_position: BadgePosition,
+    pub backdrop_badge_direction: BadgeDirection,
+    pub episode_ratings_limit: i32,
+    pub episode_badge_style: BadgeStyle,
+    pub episode_label_style: LabelStyle,
+    pub episode_badge_size: BadgeSize,
+    pub episode_position: BadgePosition,
+    pub episode_badge_direction: BadgeDirection,
+    pub episode_blur: bool,
+}
+
+impl From<&RenderSettings> for FreeKeySettingsResponse {
+    fn from(s: &RenderSettings) -> Self {
+        Self {
+            image_source: s.image_source,
+            lang: s.lang.to_string(),
+            textless: s.textless,
+            ratings_limit: s.ratings_limit,
+            ratings_order: s.ratings_order.to_string(),
+            ratings_exclude: s.ratings_exclude.to_string(),
+            poster_position: s.poster_position,
+            logo_ratings_limit: s.logo_ratings_limit,
+            backdrop_ratings_limit: s.backdrop_ratings_limit,
+            poster_badge_style: s.poster_badge_style,
+            logo_badge_style: s.logo_badge_style,
+            backdrop_badge_style: s.backdrop_badge_style,
+            poster_label_style: s.poster_label_style,
+            logo_label_style: s.logo_label_style,
+            backdrop_label_style: s.backdrop_label_style,
+            poster_badge_direction: s.poster_badge_direction,
+            poster_badge_size: s.poster_badge_size,
+            logo_badge_size: s.logo_badge_size,
+            backdrop_badge_size: s.backdrop_badge_size,
+            backdrop_position: s.backdrop_position,
+            backdrop_badge_direction: s.backdrop_badge_direction,
+            episode_ratings_limit: s.episode_ratings_limit,
+            episode_badge_style: s.episode_badge_style,
+            episode_label_style: s.episode_label_style,
+            episode_badge_size: s.episode_badge_size,
+            episode_position: s.episode_position,
+            episode_badge_direction: s.episode_badge_direction,
+            episode_blur: s.episode_blur,
+        }
+    }
+}
+
+/// `GET /api/free-key/settings` — the global default render settings the free
+/// API key serves with, so the public "Try it out" UI reflects what the server
+/// actually produces. Returns 401 when the free key is disabled (same gating as
+/// the free-key image routes). Reads from `global_settings_cache`, so it never
+/// touches the database on the hot path.
+pub async fn free_key_settings(State(state): State<Arc<AppState>>) -> Response {
+    match resolve_free_settings(&state).await {
+        Ok(settings) => axum::Json(FreeKeySettingsResponse::from(&*settings)).into_response(),
+        Err(resp) => resp,
+    }
 }
 
 /// Validate an API key and return settings. Handles both free and per-key paths.

--- a/api/src/routes/app.rs
+++ b/api/src/routes/app.rs
@@ -130,6 +130,7 @@ pub fn build_app(state: Arc<AppState>) -> Router {
 
     let compressed_routes = Router::new()
         .merge(super::auth::auth_routes())
+        .merge(super::image::free_key_settings_route())
         .merge(admin_routes)
         .merge(key_self_routes)
         .merge(openapi_route)

--- a/api/src/routes/image.rs
+++ b/api/src/routes/image.rs
@@ -111,6 +111,16 @@ pub fn image_routes() -> Router<Arc<AppState>> {
     router
 }
 
+/// Public, unauthenticated route exposing the global default render settings the
+/// free API key serves with. No rate limiter (a cheap cached read, like
+/// `/api/auth/status`); the handler itself returns 401 when the free key is off.
+pub fn free_key_settings_route() -> Router<Arc<AppState>> {
+    Router::new().route(
+        "/api/free-key/settings",
+        axum::routing::get(image::free_key_settings),
+    )
+}
+
 /// isValid route with lighter rate limiting.
 pub fn is_valid_route() -> Router<Arc<AppState>> {
     let router = Router::new().route(

--- a/api/tests/free_api_key.rs
+++ b/api/tests/free_api_key.rs
@@ -320,6 +320,100 @@ async fn no_env_var_not_locked_in_settings_response() {
     assert_eq!(json["free_api_key_locked"], false);
 }
 
+// --- GET /api/free-key/settings (public, reflects global defaults) ---
+
+#[tokio::test]
+async fn free_key_settings_rejected_when_disabled() {
+    let (app, _state) = common::setup_test_app().await;
+
+    let req = Request::builder()
+        .uri("/api/free-key/settings")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn free_key_settings_returns_defaults_when_enabled() {
+    let (app, _state) = common::setup_test_app().await;
+    let token = common::setup_admin(&app).await;
+
+    set_free_api_key_enabled(&app, &token, true).await;
+
+    let req = Request::builder()
+        .uri("/api/free-key/settings")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    // Default render settings are present and enum-coded the same as the image API.
+    assert_eq!(json["ratings_order"], "mal,imdb,lb,rt,mc,rta,tmdb,trakt,mdblist,ebert");
+    assert_eq!(json["ratings_exclude"], "");
+    assert_eq!(json["image_source"], "t");
+    assert_eq!(json["lang"], "en");
+    // Operational flags from the admin response must NOT leak onto the public endpoint.
+    assert!(json.get("free_api_key_locked").is_none());
+    assert!(json.get("fanart_available").is_none());
+}
+
+#[tokio::test]
+async fn free_key_settings_reflects_admin_changes() {
+    let (app, _state) = common::setup_test_app().await;
+    let token = common::setup_admin(&app).await;
+
+    // Enable the free key and set a custom global order + poster badge style.
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/admin/settings")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(json_body(serde_json::json!({
+            "image_source": "t",
+            "free_api_key_enabled": true,
+            "ratings_order": "imdb,tmdb",
+            "ratings_exclude": "rt",
+            "poster_badge_style": "h",
+        })))
+        .unwrap();
+    let res = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // The public endpoint should reflect those values (cache invalidated on update).
+    let req = Request::builder()
+        .uri("/api/free-key/settings")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    let body = res.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["ratings_order"], "imdb,tmdb");
+    assert_eq!(json["ratings_exclude"], "rt");
+    assert_eq!(json["poster_badge_style"], "h");
+}
+
+#[tokio::test]
+async fn free_key_settings_reflects_env_override() {
+    let (app, _state) = common::setup_test_app_with_options(TestAppOptions {
+        free_key_enabled: Some(true),
+        ..Default::default()
+    })
+    .await;
+
+    // No DB toggle needed — the env override forces the free key on.
+    let req = Request::builder()
+        .uri("/api/free-key/settings")
+        .body(Body::empty())
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+}
+
 #[tokio::test]
 async fn env_var_auth_status_reflects_override() {
     let (app, _state) = common::setup_test_app_with_options(TestAppOptions {

--- a/web/e2e/free-api-key.spec.ts
+++ b/web/e2e/free-api-key.spec.ts
@@ -363,4 +363,27 @@ test.describe('free API key card', () => {
     const res = await request.get('/api/free-key/settings')
     expect(res.status()).toBe(401)
   })
+
+  test('excluding a rating source adds ratings_exclude to the curl example', async ({ page, request }) => {
+    const token = await getAdminToken(request)
+    const settingsRes = await request.get('/api/admin/settings', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    const settings = await settingsRes.json()
+    settings.free_api_key_enabled = true
+    settings.ratings_exclude = '' // start with nothing excluded
+    await request.put('/api/admin/settings', {
+      headers: { Authorization: `Bearer ${token}` },
+      data: settings,
+    })
+
+    await page.goto('/')
+    await page.locator('text=Try it out').click()
+
+    const curlBlock = page.locator('code:has-text("curl")')
+    await expect(curlBlock).not.toContainText('ratings_exclude')
+
+    await page.locator('#free-exclude-rt').click()
+    await expect(curlBlock).toContainText('ratings_exclude=rt')
+  })
 })

--- a/web/e2e/free-api-key.spec.ts
+++ b/web/e2e/free-api-key.spec.ts
@@ -331,4 +331,36 @@ test.describe('free API key card', () => {
     // Image should still be visible (old stays until new loads)
     await expect(resultImg).toBeVisible({ timeout: 60_000 })
   })
+
+  test('card reflects the server ratings order and exposes the settings endpoint', async ({ page, request }) => {
+    const token = await getAdminToken(request)
+    const settingsRes = await request.get('/api/admin/settings', {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    const settings = await settingsRes.json()
+    settings.free_api_key_enabled = true
+    settings.ratings_order = 'tmdb,imdb,rt'
+    await request.put('/api/admin/settings', {
+      headers: { Authorization: `Bearer ${token}` },
+      data: settings,
+    })
+
+    // The public endpoint returns the operator's configured defaults.
+    const pub = await request.get('/api/free-key/settings')
+    expect(pub.status()).toBe(200)
+    expect((await pub.json()).ratings_order).toBe('tmdb,imdb,rt')
+
+    // The card's priority list reflects that order (TMDB first) — proving the
+    // async load + seeding ran end-to-end against the real server.
+    await page.goto('/')
+    await page.locator('text=Try it out').click()
+    const priorityLabels = page.locator('.border-blue-500\\/30 span.flex-1')
+    await expect(priorityLabels.first()).toHaveText('TMDB')
+  })
+
+  test('settings endpoint returns 401 when the free key is disabled', async ({ request }) => {
+    await setFreeApiKey(request, false)
+    const res = await request.get('/api/free-key/settings')
+    expect(res.status()).toBe(401)
+  })
 })

--- a/web/src/__tests__/components/FreeApiKeyCard.spec.ts
+++ b/web/src/__tests__/components/FreeApiKeyCard.spec.ts
@@ -2,12 +2,50 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount, flushPromises, VueWrapper } from '@vue/test-utils'
 import { createPinia, setActivePinia } from 'pinia'
 import FreeApiKeyCard from '@/components/FreeApiKeyCard.vue'
+import RatingsOrderList from '@/components/RatingsOrderList.vue'
 import { useAuthStore } from '@/stores/auth'
+import { DEFAULT_RATINGS_ORDER } from '@/lib/constants'
+import type { FreeKeyDefaults } from '@/lib/auth-api'
 
 vi.mock('@/stores/auth', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/stores/auth')>()
   return actual
 })
+
+/** A full FreeKeyDefaults fixture; override individual fields per test. */
+function makeDefaults(overrides: Partial<FreeKeyDefaults> = {}): FreeKeyDefaults {
+  return {
+    image_source: 't',
+    lang: 'en',
+    textless: false,
+    ratings_limit: 3,
+    ratings_order: DEFAULT_RATINGS_ORDER,
+    ratings_exclude: '',
+    poster_position: 'bc',
+    logo_ratings_limit: 5,
+    backdrop_ratings_limit: 5,
+    poster_badge_style: 'v',
+    logo_badge_style: 'v',
+    backdrop_badge_style: 'v',
+    poster_label_style: 'o',
+    logo_label_style: 'o',
+    backdrop_label_style: 'o',
+    poster_badge_direction: 'd',
+    poster_badge_size: 'm',
+    logo_badge_size: 'm',
+    backdrop_badge_size: 'm',
+    backdrop_position: 'bc',
+    backdrop_badge_direction: 'd',
+    episode_ratings_limit: 3,
+    episode_badge_style: 'v',
+    episode_label_style: 'o',
+    episode_badge_size: 'm',
+    episode_position: 'bc',
+    episode_badge_direction: 'd',
+    episode_blur: false,
+    ...overrides,
+  }
+}
 
 const SelectStub = {
   name: 'Select',
@@ -16,11 +54,14 @@ const SelectStub = {
   emits: ['update:modelValue'],
 }
 
-function mountCard(freeApiKeyEnabled = true) {
+function mountCard(freeApiKeyEnabled = true, defaults: FreeKeyDefaults | null = makeDefaults()) {
   const pinia = createPinia()
   setActivePinia(pinia)
   const auth = useAuthStore()
   auth.freeApiKeyEnabled = freeApiKeyEnabled
+  // Pre-seed so the card's onMounted load short-circuits (no network in tests).
+  // Pass `null` to exercise the fetch/fallback paths explicitly.
+  if (defaults) auth.freeKeyDefaults = defaults
 
   return mount(FreeApiKeyCard, {
     global: {
@@ -82,6 +123,7 @@ describe('FreeApiKeyCard', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
   })
 
   it('renders nothing when freeApiKeyEnabled is false', () => {
@@ -334,5 +376,90 @@ describe('FreeApiKeyCard', () => {
     await setSelectById(wrapper, 'free-image-type', 'episode')
 
     expect(wrapper.find('#free-textless').exists()).toBe(false)
+  })
+
+  // --- Reflecting the server's global defaults ---
+
+  /** Rating-priority row labels, in display order. */
+  function orderLabels(wrapper: VueWrapper) {
+    return wrapper.findComponent(RatingsOrderList).findAll('span.flex-1')
+  }
+
+  it('seeds the rating priority list from the server order', () => {
+    const wrapper = mountCard(true, makeDefaults({ ratings_order: 'tmdb,imdb,rt' }))
+    const labels = orderLabels(wrapper)
+    expect(labels[0].text()).toBe('TMDB')
+    expect(labels[1].text()).toBe('IMDb')
+  })
+
+  it('annotates dropdown defaults with the server values', () => {
+    const wrapper = mountCard(true, makeDefaults({
+      poster_badge_style: 'v',
+      poster_label_style: 't',
+      poster_badge_size: 'l',
+      ratings_limit: 5,
+      image_source: 'f',
+      lang: 'de',
+    }))
+    const text = wrapper.text()
+    expect(text).toContain('Badge style: default (Vertical)')
+    expect(text).toContain('Label style: default (Text)')
+    expect(text).toContain('Badge size: default (Large)')
+    expect(text).toContain('Max badges: default (5)')
+    expect(text).toContain('Source: default (Fanart.tv)')
+    expect(text).toContain('Language: any (de)')
+  })
+
+  it('reflects per-image-type defaults when switching image type', async () => {
+    const wrapper = mountCard(true, makeDefaults({ poster_badge_style: 'v', logo_badge_style: 'h' }))
+    expect(wrapper.text()).toContain('Badge style: default (Vertical)')
+
+    await setSelectById(wrapper, 'free-image-type', 'logo')
+    expect(wrapper.text()).toContain('Badge style: default (Horizontal)')
+  })
+
+  it('dims excluded sources in the priority list', () => {
+    const wrapper = mountCard(true, makeDefaults({ ratings_exclude: 'rt' }))
+    const rtLabel = orderLabels(wrapper).find(s => s.text() === 'Rotten Tomatoes (Critics)')
+    expect(rtLabel?.classes()).toContain('line-through')
+  })
+
+  it('does not send ratings_order when the list matches the server order', () => {
+    const wrapper = mountCard(true, makeDefaults({ ratings_order: 'tmdb,imdb,rt' }))
+    expect(findCurlCode(wrapper).text()).not.toContain('ratings_order=')
+  })
+
+  it('sends ratings_order once the user reorders away from the server order', async () => {
+    const wrapper = mountCard(true, makeDefaults({ ratings_order: 'tmdb,imdb,rt' }))
+    // Move the second item (imdb) above tmdb — diverges from the server baseline.
+    const upButtons = wrapper.findAll('button[title="Move up"]')
+    await upButtons[1].trigger('click')
+    await flushPromises()
+    expect(findCurlCode(wrapper).text()).toContain('ratings_order=imdb%2Ctmdb')
+  })
+
+  it('falls back to built-in defaults when server settings are unavailable', () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+    const wrapper = mountCard(true, null)
+    const text = wrapper.text()
+    expect(text).toContain('Badge style: default')
+    expect(text).not.toContain('Badge style: default (')
+    expect(findCurlCode(wrapper).text()).not.toContain('ratings_order=')
+  })
+
+  it('loads and reflects server defaults via the API on mount', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(makeDefaults({ poster_badge_style: 'h', lang: 'fr' })),
+      }),
+    )
+    const wrapper = mountCard(true, null)
+    await flushPromises()
+
+    const text = wrapper.text()
+    expect(text).toContain('Badge style: default (Horizontal)')
+    expect(text).toContain('Language: any (fr)')
   })
 })

--- a/web/src/__tests__/components/FreeApiKeyCard.spec.ts
+++ b/web/src/__tests__/components/FreeApiKeyCard.spec.ts
@@ -84,6 +84,13 @@ function mountCard(freeApiKeyEnabled = true, defaults: FreeKeyDefaults | null = 
           template: '<button :disabled="disabled" :type="type" @click="$emit(\'click\')"><slot /></button>',
           props: ['disabled', 'variant', 'size', 'type'],
         },
+        Checkbox: {
+          name: 'Checkbox',
+          template: '<button type="button" role="checkbox" :id="id" :aria-checked="modelValue ? \'true\' : \'false\'" @click="$emit(\'update:modelValue\', !modelValue)" />',
+          props: ['modelValue', 'id', 'ariaLabel'],
+          emits: ['update:modelValue'],
+        },
+        Label: { template: '<label><slot /></label>', props: ['for'] },
         ChevronRight: { template: '<svg />' },
         Loader2: { template: '<svg />' },
       },
@@ -418,10 +425,38 @@ describe('FreeApiKeyCard', () => {
     expect(wrapper.text()).toContain('Badge style: default (Horizontal)')
   })
 
-  it('dims excluded sources in the priority list', () => {
+  it('dims excluded sources in the priority list and pre-checks them', () => {
     const wrapper = mountCard(true, makeDefaults({ ratings_exclude: 'rt' }))
     const rtLabel = orderLabels(wrapper).find(s => s.text() === 'Rotten Tomatoes (Critics)')
     expect(rtLabel?.classes()).toContain('line-through')
+    // The exclude checkbox for rt is pre-checked from the server baseline.
+    expect(wrapper.find('#free-exclude-rt').attributes('aria-checked')).toBe('true')
+    expect(wrapper.find('#free-exclude-imdb').attributes('aria-checked')).toBe('false')
+  })
+
+  it('does not send ratings_exclude when the selection matches the server baseline', () => {
+    const wrapper = mountCard(true, makeDefaults({ ratings_exclude: 'rt' }))
+    expect(findCurlCode(wrapper).text()).not.toContain('ratings_exclude=')
+  })
+
+  it('excluding a source adds it to the curl and dims it in the list', async () => {
+    const wrapper = mountCard(true, makeDefaults({ ratings_exclude: '' }))
+    await wrapper.find('#free-exclude-rt').trigger('click')
+    await flushPromises()
+
+    expect(findCurlCode(wrapper).text()).toContain('ratings_exclude=rt')
+    const rtLabel = orderLabels(wrapper).find(s => s.text() === 'Rotten Tomatoes (Critics)')
+    expect(rtLabel?.classes()).toContain('line-through')
+  })
+
+  it('unchecking a server exclusion emits an empty ratings_exclude override', async () => {
+    const wrapper = mountCard(true, makeDefaults({ ratings_exclude: 'rt' }))
+    await wrapper.find('#free-exclude-rt').trigger('click')
+    await flushPromises()
+
+    // Empty value (trailing `=`) is required to override the server's exclusion.
+    expect(findCurlCode(wrapper).text()).toContain('ratings_exclude=')
+    expect(findCurlCode(wrapper).text()).not.toContain('ratings_exclude=rt')
   })
 
   it('does not send ratings_order when the list matches the server order', () => {

--- a/web/src/__tests__/components/RatingsOrderList.spec.ts
+++ b/web/src/__tests__/components/RatingsOrderList.spec.ts
@@ -13,6 +13,12 @@ function mountWithModel(initial: string[] = ['imdb', 'tmdb', 'rt'], compact = fa
   return wrapper
 }
 
+function mountWithExcluded(initial: string[], excluded: string[]) {
+  return mount(RatingsOrderList, {
+    props: { modelValue: initial, excluded },
+  })
+}
+
 describe('RatingsOrderList', () => {
   it('renders all items in correct order', () => {
     const order = ['imdb', 'tmdb', 'rt']
@@ -133,6 +139,39 @@ describe('RatingsOrderList', () => {
     const wrapper = mountWithModel(['imdb', 'tmdb'], false)
     const container = wrapper.find('.space-y-1')
     expect(container.exists()).toBe(true)
+  })
+
+  describe('excluded prop', () => {
+    it('dims and strikes through excluded sources only', () => {
+      const wrapper = mountWithExcluded(['imdb', 'tmdb', 'rt'], ['tmdb'])
+      const rows = wrapper.findAll('.flex.items-center')
+      expect(rows[1].classes()).toContain('opacity-40')
+      expect(rows[0].classes()).not.toContain('opacity-40')
+
+      const labels = wrapper.findAll('span.flex-1')
+      expect(labels[1].classes()).toContain('line-through')
+      expect(labels[1].attributes('title')).toBeTruthy()
+      expect(labels[0].classes()).not.toContain('line-through')
+      expect(labels[0].attributes('title')).toBeUndefined()
+    })
+
+    it('applies no exclusion styling when excluded is omitted', () => {
+      const wrapper = mountWithModel(['imdb', 'tmdb'])
+      for (const row of wrapper.findAll('.flex.items-center')) {
+        expect(row.classes()).not.toContain('opacity-40')
+      }
+      for (const label of wrapper.findAll('span.flex-1')) {
+        expect(label.classes()).not.toContain('line-through')
+      }
+    })
+
+    it('keeps excluded items functional — move buttons still reorder them', async () => {
+      const wrapper = mountWithExcluded(['imdb', 'tmdb', 'rt'], ['tmdb'])
+      const buttons = wrapper.findAll('button')
+      // Move tmdb (excluded, second row) up — up button is index 2.
+      await buttons[2].trigger('click')
+      expect(wrapper.emitted('update:modelValue')![0][0]).toEqual(['tmdb', 'imdb', 'rt'])
+    })
   })
 
   it('handles all 10 rating sources', () => {

--- a/web/src/__tests__/lib/constants.spec.ts
+++ b/web/src/__tests__/lib/constants.spec.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from 'vitest'
-import { ALL_RATING_SOURCES, DEFAULT_RATINGS_ORDER, parseRatingsOrder, parseRatingsExclude } from '@/lib/constants'
+import {
+  ALL_RATING_SOURCES,
+  DEFAULT_RATINGS_ORDER,
+  parseRatingsOrder,
+  parseRatingsExclude,
+  BADGE_STYLE_LABELS,
+  BADGE_DIRECTION_LABELS,
+  LABEL_STYLE_LABELS,
+  BADGE_SIZE_LABELS,
+  IMAGE_SOURCE_LABELS,
+  POSITION_LABELS,
+} from '@/lib/constants'
 
 describe('ALL_RATING_SOURCES', () => {
   it('has 10 rating sources', () => {
@@ -82,5 +93,34 @@ describe('parseRatingsExclude', () => {
 
   it('drops unknown keys', () => {
     expect(parseRatingsExclude('rt,bogus,mal')).toEqual(['rt', 'mal'])
+  })
+})
+
+describe('enum code → label maps', () => {
+  it('badge style/direction map the h/v/d codes', () => {
+    for (const map of [BADGE_STYLE_LABELS, BADGE_DIRECTION_LABELS]) {
+      expect(map.h).toBe('Horizontal')
+      expect(map.v).toBe('Vertical')
+      expect(map.d).toBe('Auto')
+    }
+  })
+
+  it('label style maps the t/i/o codes', () => {
+    expect(LABEL_STYLE_LABELS).toEqual({ t: 'Text', i: 'Icon', o: 'Official' })
+  })
+
+  it('badge size maps every xs–xl code', () => {
+    expect(Object.keys(BADGE_SIZE_LABELS).sort()).toEqual(['l', 'm', 's', 'xl', 'xs'])
+    expect(BADGE_SIZE_LABELS.m).toBe('Medium')
+  })
+
+  it('image source maps the t/f codes', () => {
+    expect(IMAGE_SOURCE_LABELS).toEqual({ t: 'TMDB', f: 'Fanart.tv' })
+  })
+
+  it('position maps all eight placement codes', () => {
+    expect(Object.keys(POSITION_LABELS)).toHaveLength(8)
+    expect(POSITION_LABELS.bc).toBe('Bottom Center')
+    expect(POSITION_LABELS.tr).toBe('Top Right')
   })
 })

--- a/web/src/__tests__/views/LoginView.spec.ts
+++ b/web/src/__tests__/views/LoginView.spec.ts
@@ -12,9 +12,11 @@ const mockAuthStore = {
   checkSetupRequired: vi.fn().mockResolvedValue(false),
   login: vi.fn(),
   loginWithApiKey: vi.fn(),
+  loadFreeKeyDefaults: vi.fn().mockResolvedValue(undefined),
   isAuthenticated: false,
   freeApiKeyEnabled: false,
   disablePublicPages: false,
+  freeKeyDefaults: null,
 }
 
 vi.mock('vue-router', () => ({

--- a/web/src/components/FreeApiKeyCard.vue
+++ b/web/src/components/FreeApiKeyCard.vue
@@ -4,6 +4,7 @@ import { useAuthStore } from '@/stores/auth'
 import {
   FREE_API_KEY,
   LANGUAGES,
+  ALL_RATING_SOURCES,
   DEFAULT_RATINGS_ORDER,
   parseRatingsOrder,
   parseRatingsExclude,
@@ -16,6 +17,8 @@ import {
 } from '@/lib/constants'
 import RatingsOrderList from '@/components/RatingsOrderList.vue'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Label } from '@/components/ui/label'
 import { Input } from '@/components/ui/input'
 import {
   Select,
@@ -84,18 +87,38 @@ const sizeOptions = computed(() => {
   ]
 })
 
-// Source keys the server excludes from badges — shown dimmed in the priority list.
-const excludedSources = computed(() => parseRatingsExclude(defaults.value?.ratings_exclude ?? ''))
+// Rating sources to exclude from badges. Seeded from the server's exclusion list
+// and editable via the checkboxes below; excluded sources are dimmed in the
+// priority list. Sent as a `ratings_exclude` override only when changed.
+const ratingsExcludeList = ref<string[]>([])
+const excludeBaseline = ref<string[]>([])
+const ratingsExcludeChanged = computed(
+  () => ratingsExcludeList.value.join(',') !== excludeBaseline.value.join(','),
+)
 
-// When the server defaults arrive, adopt the server's rating order as the new
-// baseline. Only overwrite the visible list if the user hasn't reordered yet,
-// so a slow fetch never clobbers an in-progress edit.
+function isExcluded(key: string): boolean {
+  return ratingsExcludeList.value.includes(key)
+}
+function toggleExclude(key: string, checked: boolean) {
+  const set = new Set(ratingsExcludeList.value)
+  if (checked) set.add(key)
+  else set.delete(key)
+  // Keep canonical source order so the emitted value is stable regardless of click order.
+  ratingsExcludeList.value = ALL_RATING_SOURCES.map(s => s.key).filter(k => set.has(k))
+}
+
+// When the server defaults arrive, adopt the server's rating order and exclusion
+// list as the new baselines. Only overwrite a list if the user hasn't edited it
+// yet, so a slow fetch never clobbers an in-progress edit.
 watch(defaults, (d) => {
-  if (!d?.ratings_order) return
+  if (!d) return
   const serverOrder = parseRatingsOrder(d.ratings_order)
-  const wasPristine = !ratingsOrderChanged.value
+  if (!ratingsOrderChanged.value) ratingsOrderList.value = [...serverOrder]
   baselineOrder.value = serverOrder
-  if (wasPristine) ratingsOrderList.value = [...serverOrder]
+
+  const serverExclude = parseRatingsExclude(d.ratings_exclude)
+  if (!ratingsExcludeChanged.value) ratingsExcludeList.value = [...serverExclude]
+  excludeBaseline.value = serverExclude
 }, { immediate: true })
 
 // --- Per-image-type server defaults reflected in the dropdown "default" labels ---
@@ -182,6 +205,8 @@ const queryString = computed(() => {
   const sizeVal = imageSize.value === 'default' ? '' : imageSize.value
   if (sizeVal) params.set('imageSize', sizeVal)
   if (ratingsOrderChanged.value) params.set('ratings_order', ratingsOrderList.value.join(','))
+  // Emit even when empty, so unchecking the server's exclusions clears them.
+  if (ratingsExcludeChanged.value) params.set('ratings_exclude', ratingsExcludeList.value.join(','))
   if (badgeStyle.value !== 'default') params.set('badge_style', badgeStyle.value)
   if (labelStyle.value !== 'default') params.set('label_style', labelStyle.value)
   if (badgeSize.value !== 'default') params.set('badge_size', badgeSize.value)
@@ -384,7 +409,35 @@ async function handleFetch() {
         </div>
         <div class="space-y-1 flex flex-col items-center">
           <p class="text-xs text-muted-foreground">Rating priority</p>
-          <RatingsOrderList v-model="ratingsOrderList" :excluded="excludedSources" compact />
+          <RatingsOrderList v-model="ratingsOrderList" :excluded="ratingsExcludeList" compact />
+        </div>
+        <div class="space-y-1 flex flex-col items-center">
+          <p class="text-xs text-muted-foreground">Exclude ratings</p>
+          <div class="grid grid-cols-2 gap-x-3 gap-y-1.5 max-w-sm w-full">
+            <div
+              v-for="source in ALL_RATING_SOURCES"
+              :key="source.key"
+              class="flex items-start gap-1.5 text-left"
+            >
+              <Checkbox
+                :id="`free-exclude-${source.key}`"
+                :model-value="isExcluded(source.key)"
+                :aria-label="`Exclude ${source.label}`"
+                class="bg-background shrink-0 mt-0.5"
+                @update:model-value="(v) => toggleExclude(source.key, !!v)"
+              />
+              <Label
+                :for="`free-exclude-${source.key}`"
+                class="flex items-start gap-1.5 text-xs font-normal leading-snug cursor-pointer min-w-0"
+              >
+                <span
+                  class="inline-block w-2 h-2 rounded-full shrink-0 mt-1"
+                  :style="{ backgroundColor: source.color }"
+                ></span>
+                <span>{{ source.label }}</span>
+              </Label>
+            </div>
+          </div>
         </div>
         <code class="block text-xs font-mono bg-muted px-3 py-2 rounded text-muted-foreground break-all select-all">{{ curlExample }}</code>
         <div class="flex flex-wrap gap-2">

--- a/web/src/components/FreeApiKeyCard.vue
+++ b/web/src/components/FreeApiKeyCard.vue
@@ -1,7 +1,19 @@
 <script setup lang="ts">
-import { ref, computed, watch, onUnmounted } from 'vue'
+import { ref, computed, watch, onMounted, onUnmounted } from 'vue'
 import { useAuthStore } from '@/stores/auth'
-import { FREE_API_KEY, LANGUAGES, DEFAULT_RATINGS_ORDER, parseRatingsOrder } from '@/lib/constants'
+import {
+  FREE_API_KEY,
+  LANGUAGES,
+  DEFAULT_RATINGS_ORDER,
+  parseRatingsOrder,
+  parseRatingsExclude,
+  BADGE_STYLE_LABELS,
+  BADGE_DIRECTION_LABELS,
+  LABEL_STYLE_LABELS,
+  BADGE_SIZE_LABELS,
+  IMAGE_SOURCE_LABELS,
+  POSITION_LABELS,
+} from '@/lib/constants'
 import RatingsOrderList from '@/components/RatingsOrderList.vue'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -19,6 +31,16 @@ const isOpen = ref(false)
 
 const auth = useAuthStore()
 
+// Server's global default render settings, so the form reflects what the free
+// key actually produces rather than hardcoded frontend defaults. Loaded lazily
+// (and cached) by the store; `defaults` stays null until it resolves, in which
+// case every control gracefully falls back to its built-in default.
+const defaults = computed(() => auth.freeKeyDefaults)
+
+onMounted(() => {
+  if (auth.freeApiKeyEnabled) auth.loadFreeKeyDefaults()
+})
+
 const idType = ref<'imdb' | 'tmdb' | 'tvdb'>('imdb')
 const imageType = ref<'poster' | 'logo' | 'backdrop' | 'episode'>('poster')
 const idValue = ref('tt0013442')
@@ -33,8 +55,13 @@ const imagePosition = ref('default')
 const imageSource = ref('default')
 const textless = ref('default')
 const ratingsOrderList = ref<string[]>(parseRatingsOrder(DEFAULT_RATINGS_ORDER))
+// Baseline the user's order is compared against to decide whether to send a
+// `ratings_order` override — the server's order once loaded, else the frontend default.
+const baselineOrder = ref<string[]>(parseRatingsOrder(DEFAULT_RATINGS_ORDER))
 const blur = ref('default')
-const ratingsOrderChanged = ref(false)
+const ratingsOrderChanged = computed(
+  () => ratingsOrderList.value.join(',') !== baselineOrder.value.join(','),
+)
 const fetchError = ref('')
 const fetchLoading = ref(false)
 const resultUrl = ref('')
@@ -57,10 +84,62 @@ const sizeOptions = computed(() => {
   ]
 })
 
-watch(ratingsOrderList, (newOrder) => {
-  const defaultOrder = parseRatingsOrder(DEFAULT_RATINGS_ORDER)
-  ratingsOrderChanged.value = newOrder.join(',') !== defaultOrder.join(',')
-}, { deep: true })
+// Source keys the server excludes from badges — shown dimmed in the priority list.
+const excludedSources = computed(() => parseRatingsExclude(defaults.value?.ratings_exclude ?? ''))
+
+// When the server defaults arrive, adopt the server's rating order as the new
+// baseline. Only overwrite the visible list if the user hasn't reordered yet,
+// so a slow fetch never clobbers an in-progress edit.
+watch(defaults, (d) => {
+  if (!d?.ratings_order) return
+  const serverOrder = parseRatingsOrder(d.ratings_order)
+  const wasPristine = !ratingsOrderChanged.value
+  baselineOrder.value = serverOrder
+  if (wasPristine) ratingsOrderList.value = [...serverOrder]
+}, { immediate: true })
+
+// --- Per-image-type server defaults reflected in the dropdown "default" labels ---
+
+const typeDefaults = computed(() => {
+  const d = defaults.value
+  if (!d) return null
+  switch (imageType.value) {
+    case 'logo':
+      return { badge_style: d.logo_badge_style, label_style: d.logo_label_style, badge_size: d.logo_badge_size, ratings_limit: d.logo_ratings_limit, position: null as string | null, badge_direction: null as string | null }
+    case 'backdrop':
+      return { badge_style: d.backdrop_badge_style, label_style: d.backdrop_label_style, badge_size: d.backdrop_badge_size, ratings_limit: d.backdrop_ratings_limit, position: d.backdrop_position, badge_direction: d.backdrop_badge_direction }
+    case 'episode':
+      return { badge_style: d.episode_badge_style, label_style: d.episode_label_style, badge_size: d.episode_badge_size, ratings_limit: d.episode_ratings_limit, position: d.episode_position, badge_direction: d.episode_badge_direction }
+    default: // poster
+      return { badge_style: d.poster_badge_style, label_style: d.poster_label_style, badge_size: d.poster_badge_size, ratings_limit: d.ratings_limit, position: d.poster_position, badge_direction: d.poster_badge_direction }
+  }
+})
+
+/** Build a "<base>: default (<resolved>)" label, or plain "<base>: default" until loaded. */
+function annotate(base: string, value: string | null | undefined, map: Record<string, string>): string {
+  if (value == null) return `${base}: default`
+  return `${base}: default (${map[value] ?? value})`
+}
+
+const langDefaultLabel = computed(() =>
+  defaults.value ? `Language: any (${defaults.value.lang})` : 'Language: any',
+)
+const ratingsLimitDefaultLabel = computed(() => {
+  const limit = typeDefaults.value?.ratings_limit
+  return limit == null ? 'Max badges: default' : `Max badges: default (${limit})`
+})
+const badgeStyleDefaultLabel = computed(() => annotate('Badge style', typeDefaults.value?.badge_style, BADGE_STYLE_LABELS))
+const labelStyleDefaultLabel = computed(() => annotate('Label style', typeDefaults.value?.label_style, LABEL_STYLE_LABELS))
+const badgeSizeDefaultLabel = computed(() => annotate('Badge size', typeDefaults.value?.badge_size, BADGE_SIZE_LABELS))
+const imageSourceDefaultLabel = computed(() => annotate('Source', defaults.value?.image_source, IMAGE_SOURCE_LABELS))
+const positionDefaultLabel = computed(() => annotate('Position', typeDefaults.value?.position, POSITION_LABELS))
+const badgeDirectionDefaultLabel = computed(() => annotate('Direction', typeDefaults.value?.badge_direction, BADGE_DIRECTION_LABELS))
+const textlessDefaultLabel = computed(() =>
+  defaults.value ? `Textless: default (${defaults.value.textless ? 'Yes' : 'No'})` : 'Textless: default',
+)
+const blurDefaultLabel = computed(() =>
+  defaults.value ? `Blur: default (${defaults.value.episode_blur ? 'Yes' : 'No'})` : 'Blur: default',
+)
 
 // Reset size when switching image type if the current size is invalid,
 // and reset poster-only controls when switching away from poster
@@ -189,7 +268,7 @@ async function handleFetch() {
               <SelectValue placeholder="Language: any" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="any">Language: any</SelectItem>
+              <SelectItem value="any">{{ langDefaultLabel }}</SelectItem>
               <SelectItem v-for="l in LANGUAGES" :key="l.code" :value="l.code">
                 {{ l.code }} - {{ l.name }}
               </SelectItem>
@@ -200,7 +279,7 @@ async function handleFetch() {
               <SelectValue placeholder="Max badges: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">Max badges: default</SelectItem>
+              <SelectItem value="default">{{ ratingsLimitDefaultLabel }}</SelectItem>
               <SelectItem v-for="n in 9" :key="n - 1" :value="String(n - 1)">
                 {{ n - 1 }} {{ n - 1 === 1 ? 'badge' : 'badges' }}
               </SelectItem>
@@ -211,7 +290,7 @@ async function handleFetch() {
               <SelectValue placeholder="Badge style: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">Badge style: default</SelectItem>
+              <SelectItem value="default">{{ badgeStyleDefaultLabel }}</SelectItem>
               <SelectItem value="h">Horizontal</SelectItem>
               <SelectItem value="v">Vertical</SelectItem>
             </SelectContent>
@@ -221,7 +300,7 @@ async function handleFetch() {
               <SelectValue placeholder="Label style: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">Label style: default</SelectItem>
+              <SelectItem value="default">{{ labelStyleDefaultLabel }}</SelectItem>
               <SelectItem value="t">Text</SelectItem>
               <SelectItem value="i">Icon</SelectItem>
               <SelectItem value="o">Official</SelectItem>
@@ -232,7 +311,7 @@ async function handleFetch() {
               <SelectValue placeholder="Badge size: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">Badge size: default</SelectItem>
+              <SelectItem value="default">{{ badgeSizeDefaultLabel }}</SelectItem>
               <SelectItem value="xs">Extra Small</SelectItem>
               <SelectItem value="s">Small</SelectItem>
               <SelectItem value="m">Medium</SelectItem>
@@ -245,7 +324,7 @@ async function handleFetch() {
               <SelectValue placeholder="Source: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">Source: default</SelectItem>
+              <SelectItem value="default">{{ imageSourceDefaultLabel }}</SelectItem>
               <SelectItem value="t">TMDB</SelectItem>
               <SelectItem value="f">Fanart.tv</SelectItem>
             </SelectContent>
@@ -256,7 +335,7 @@ async function handleFetch() {
                 <SelectValue placeholder="Textless: default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">Textless: default</SelectItem>
+                <SelectItem value="default">{{ textlessDefaultLabel }}</SelectItem>
                 <SelectItem value="true">Yes</SelectItem>
                 <SelectItem value="false">No</SelectItem>
               </SelectContent>
@@ -268,7 +347,7 @@ async function handleFetch() {
                 <SelectValue placeholder="Position: default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">Position: default</SelectItem>
+                <SelectItem value="default">{{ positionDefaultLabel }}</SelectItem>
                 <SelectItem value="bc">Bottom Center</SelectItem>
                 <SelectItem value="tc">Top Center</SelectItem>
                 <SelectItem value="l">Left</SelectItem>
@@ -284,7 +363,7 @@ async function handleFetch() {
                 <SelectValue placeholder="Direction: default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">Direction: default</SelectItem>
+                <SelectItem value="default">{{ badgeDirectionDefaultLabel }}</SelectItem>
                 <SelectItem value="h">Horizontal</SelectItem>
                 <SelectItem value="v">Vertical</SelectItem>
               </SelectContent>
@@ -296,7 +375,7 @@ async function handleFetch() {
                 <SelectValue placeholder="Blur: default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">Blur: default</SelectItem>
+                <SelectItem value="default">{{ blurDefaultLabel }}</SelectItem>
                 <SelectItem value="true">Yes</SelectItem>
                 <SelectItem value="false">No</SelectItem>
               </SelectContent>
@@ -305,7 +384,7 @@ async function handleFetch() {
         </div>
         <div class="space-y-1 flex flex-col items-center">
           <p class="text-xs text-muted-foreground">Rating priority</p>
-          <RatingsOrderList v-model="ratingsOrderList" compact />
+          <RatingsOrderList v-model="ratingsOrderList" :excluded="excludedSources" compact />
         </div>
         <code class="block text-xs font-mono bg-muted px-3 py-2 rounded text-muted-foreground break-all select-all">{{ curlExample }}</code>
         <div class="flex flex-wrap gap-2">

--- a/web/src/components/RatingsOrderList.vue
+++ b/web/src/components/RatingsOrderList.vue
@@ -3,9 +3,15 @@ import { ALL_RATING_SOURCES } from '@/lib/constants'
 
 const model = defineModel<string[]>({ required: true })
 
-defineProps<{
+const props = defineProps<{
   compact?: boolean
+  /** Source keys the server excludes — shown dimmed/struck-through, not removed. */
+  excluded?: string[]
 }>()
+
+function isExcluded(key: string) {
+  return props.excluded?.includes(key) ?? false
+}
 
 function moveItem(from: number, to: number) {
   if (to < 0 || to >= model.value.length) return
@@ -26,14 +32,18 @@ function getRatingSource(key: string) {
       v-for="(key, index) in model"
       :key="key"
       class="flex items-center gap-2 rounded border bg-background"
-      :class="compact ? 'px-1.5 py-1' : 'px-2 py-1.5'"
+      :class="[compact ? 'px-1.5 py-1' : 'px-2 py-1.5', { 'opacity-40': isExcluded(key) }]"
     >
       <span class="text-muted-foreground text-xs select-none w-4 text-right">{{ index + 1 }}</span>
       <span
         class="inline-block w-2.5 h-2.5 rounded-full shrink-0"
         :style="{ backgroundColor: getRatingSource(key)?.color }"
       ></span>
-      <span class="text-sm flex-1">{{ getRatingSource(key)?.label || key }}</span>
+      <span
+        class="text-sm flex-1"
+        :class="{ 'line-through': isExcluded(key) }"
+        :title="isExcluded(key) ? 'Excluded by the server\'s default settings' : undefined"
+      >{{ getRatingSource(key)?.label || key }}</span>
       <button
         type="button"
         class="inline-flex items-center justify-center rounded border text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-30 disabled:pointer-events-none"

--- a/web/src/lib/auth-api.ts
+++ b/web/src/lib/auth-api.ts
@@ -1,8 +1,46 @@
 const BASE_URL = import.meta.env.VITE_API_URL || ''
 
+/**
+ * Global default render settings the free API key serves with, returned by
+ * `GET /api/free-key/settings`. Enum-coded fields use the same short codes as
+ * the image query params (e.g. badge style `h`/`v`/`d`, image source `t`/`f`).
+ */
+export interface FreeKeyDefaults {
+  image_source: string
+  lang: string
+  textless: boolean
+  ratings_limit: number
+  ratings_order: string
+  ratings_exclude: string
+  poster_position: string
+  logo_ratings_limit: number
+  backdrop_ratings_limit: number
+  poster_badge_style: string
+  logo_badge_style: string
+  backdrop_badge_style: string
+  poster_label_style: string
+  logo_label_style: string
+  backdrop_label_style: string
+  poster_badge_direction: string
+  poster_badge_size: string
+  logo_badge_size: string
+  backdrop_badge_size: string
+  backdrop_position: string
+  backdrop_badge_direction: string
+  episode_ratings_limit: number
+  episode_badge_style: string
+  episode_label_style: string
+  episode_badge_size: string
+  episode_position: string
+  episode_badge_direction: string
+  episode_blur: boolean
+}
+
 export const authApi = {
   status: (): Promise<Response> =>
     fetch(`${BASE_URL}/api/auth/status`),
+  freeKeySettings: (): Promise<Response> =>
+    fetch(`${BASE_URL}/api/free-key/settings`),
   setup: (username: string, password: string): Promise<Response> =>
     fetch(`${BASE_URL}/api/auth/setup`, {
       method: 'POST',

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -63,6 +63,20 @@ export const ALL_RATING_SOURCES = [
 
 export const DEFAULT_RATINGS_ORDER = 'mal,imdb,lb,rt,mc,rta,tmdb,trakt,mdblist,ebert'
 
+// Maps from the short enum codes used by the image query params / settings API
+// to human-readable labels. Used to show what a server "default" resolves to in
+// the free-key "Try it out" form. `d` (style/direction) means "auto" — resolved
+// at render time from the badge position/direction.
+export const BADGE_STYLE_LABELS: Record<string, string> = { h: 'Horizontal', v: 'Vertical', d: 'Auto' }
+export const BADGE_DIRECTION_LABELS: Record<string, string> = { h: 'Horizontal', v: 'Vertical', d: 'Auto' }
+export const LABEL_STYLE_LABELS: Record<string, string> = { t: 'Text', i: 'Icon', o: 'Official' }
+export const BADGE_SIZE_LABELS: Record<string, string> = { xs: 'Extra Small', s: 'Small', m: 'Medium', l: 'Large', xl: 'Extra Large' }
+export const IMAGE_SOURCE_LABELS: Record<string, string> = { t: 'TMDB', f: 'Fanart.tv' }
+export const POSITION_LABELS: Record<string, string> = {
+  bc: 'Bottom Center', tc: 'Top Center', l: 'Left', r: 'Right',
+  tl: 'Top Left', tr: 'Top Right', bl: 'Bottom Left', br: 'Bottom Right',
+}
+
 export function parseRatingsOrder(order: string): string[] {
   const keys = order ? order.split(',').map(k => k.trim()).filter(Boolean) : []
   const allKeys = ALL_RATING_SOURCES.map(s => s.key)

--- a/web/src/stores/auth.ts
+++ b/web/src/stores/auth.ts
@@ -1,12 +1,36 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
-import { authApi } from '@/lib/auth-api'
+import { authApi, type FreeKeyDefaults } from '@/lib/auth-api'
 
 export const useAuthStore = defineStore('auth', () => {
   const token = ref<string | null>(localStorage.getItem('token'))
   const setupRequired = ref<boolean | null>(null)
   const freeApiKeyEnabled = ref(false)
   const disablePublicPages = ref(false)
+
+  // Global default render settings the free key serves with. Fetched lazily and
+  // memoized so the card (rendered on both the landing and login pages) reads it
+  // once per session; the backend serves it from cache, so no repeat DB reads.
+  const freeKeyDefaults = ref<FreeKeyDefaults | null>(null)
+  let freeKeyDefaultsPromise: Promise<void> | null = null
+
+  async function loadFreeKeyDefaults(): Promise<void> {
+    if (freeKeyDefaults.value) return
+    if (freeKeyDefaultsPromise) return freeKeyDefaultsPromise
+    freeKeyDefaultsPromise = (async () => {
+      try {
+        const res = await authApi.freeKeySettings()
+        if (res.ok) {
+          freeKeyDefaults.value = await res.json()
+        }
+      } catch {
+        // Non-fatal: the card falls back to its built-in defaults.
+      } finally {
+        freeKeyDefaultsPromise = null
+      }
+    })()
+    return freeKeyDefaultsPromise
+  }
 
   // API key session state (sessionStorage so it clears on tab close)
   const apiKeyToken = ref<string | null>(sessionStorage.getItem('apiKeyToken'))
@@ -94,6 +118,8 @@ export const useAuthStore = defineStore('auth', () => {
     setupRequired,
     freeApiKeyEnabled,
     disablePublicPages,
+    freeKeyDefaults,
+    loadFreeKeyDefaults,
     checkSetupRequired,
     setup,
     login,

--- a/web/src/views/LandingView.vue
+++ b/web/src/views/LandingView.vue
@@ -189,7 +189,7 @@ const episodes = [
           <div class="pt-4">
             <NavButtons />
           </div>
-          <div class="pt-4 max-w-lg mx-auto">
+          <div class="pt-4 max-w-xl mx-auto">
             <FreeApiKeyCard />
           </div>
           <!-- Feature cards -->

--- a/web/src/views/LoginView.vue
+++ b/web/src/views/LoginView.vue
@@ -65,7 +65,7 @@ function toggleMode() {
 </script>
 
 <template>
-  <main v-if="!checking" class="min-h-screen flex items-center justify-center">
+  <main v-if="!checking" class="min-h-screen flex flex-col items-center justify-center gap-6 px-4 py-8">
     <div class="w-full max-w-sm space-y-6">
       <div class="text-center">
         <h1 class="text-2xl font-bold">OpenPosterDB</h1>
@@ -126,6 +126,11 @@ function toggleMode() {
         <router-link to="/" class="underline hover:text-foreground">&larr; Back to home</router-link>
       </p>
 
+    </div>
+
+    <!-- The free-key card sits outside the narrow form column so it can use the
+         same (wider) width as the homepage without stretching the login form. -->
+    <div v-if="auth.freeApiKeyEnabled" class="w-full max-w-xl">
       <FreeApiKeyCard />
     </div>
   </main>


### PR DESCRIPTION
## Problem

The free API key serves images using the **instance's global render settings**, but the "Try it out" section of the free-key card (shown on the landing and login pages) displayed **hardcoded frontend defaults** and offered no way to preview rating **exclusions**. When an operator changed the global rating order/defaults or excluded sources, the card's priority list and the copy-pasteable `curl` example no longer reflected what the key actually produces.

## Change

**Backend** — new public endpoint `GET /api/free-key/settings`:
- Returns the global default render settings the free key serves with.
- Gated identically to the free-key image routes (401 when the key is disabled, incl. the env-override path).
- Served from the existing `global_settings_cache` (invalidated on settings update) — **no extra DB reads**.
- Returns a trimmed `FreeKeySettingsResponse` that deliberately omits operational flags (`fanart_available`, `free_api_key_locked`) so the public endpoint can't leak them.

**Frontend** — `FreeApiKeyCard` (fetches the defaults once via a memoized auth-store action):
- Seeds the rating-priority list from the server's order, emitting a `ratings_order` override only once the user reorders away from it.
- Annotates each dropdown's "default" with the server's resolved per-image-type value (e.g. *Badge style: default (Vertical)*, *Max badges: default (3)*, *Language: any (en)*).
- **Adds an "Exclude ratings" checkbox grid** seeded from the server's exclusion list. Toggling a source emits a `ratings_exclude` override (including an *empty* value to clear a server-set exclusion) and dims it live in the priority list.
- Falls back gracefully to the built-in defaults if the fetch fails.

## Testing
- `cargo test` — all backend tests pass, incl. new tests for the endpoint (disabled→401, defaults, reflects admin changes + cache invalidation, env override, no operational-flag leakage).
- `vitest run` — 287 unit tests pass, incl. coverage for the dropdown annotations, server-order seeding, the exclude checkboxes (seed/dim/override + empty-clear), the `RatingsOrderList` `excluded` prop, and the enum→label maps.
- `npm run build-only` + oxlint/eslint clean.
- New e2e tests assert the endpoint is wired in the real server, the priority list reflects a server-configured order end-to-end, and excluding a source updates the `curl` example.

A multi-agent adversarial review of the first commit surfaced no correctness/security issues; its two confirmed findings (test-coverage gaps) are addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)