### PR TITLE
fix: offer up to 10 rating badges in the free-key card

### DIFF
--- a/web/src/__tests__/components/FreeApiKeyCard.spec.ts
+++ b/web/src/__tests__/components/FreeApiKeyCard.spec.ts
@@ -145,6 +145,20 @@ describe('FreeApiKeyCard', () => {
     expect(wrapper.text()).toContain('Free API Key Available')
   })
 
+  it('offers ratings-limit options up to 10 badges (one per rating source)', () => {
+    const wrapper = mountCard(true)
+    const ratingsSelect = wrapper
+      .findAllComponents(SelectStub)
+      .find((s) => s.find('#free-ratings-limit').exists())
+    expect(ratingsSelect).toBeTruthy()
+    const text = ratingsSelect!.text()
+    expect(text).toContain('1 badge')
+    expect(text).toContain('9 badges')
+    expect(text).toContain('10 badges')
+    // 10 is the backend max (validate_ratings_limit allows 0–10); don't offer more.
+    expect(text).not.toContain('11 badges')
+  })
+
   it('curlExample uses .jpg for poster and .png for logo', async () => {
     const wrapper = mountCard(true)
     expect(findCurlCode(wrapper).text()).toContain('.jpg')

--- a/web/src/components/FreeApiKeyCard.vue
+++ b/web/src/components/FreeApiKeyCard.vue
@@ -311,7 +311,7 @@ async function handleFetch() {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="default">{{ ratingsLimitDefaultLabel }}</SelectItem>
-              <SelectItem v-for="n in 9" :key="n - 1" :value="String(n - 1)">
+              <SelectItem v-for="n in 11" :key="n - 1" :value="String(n - 1)">
                 {{ n - 1 }} {{ n - 1 === 1 ? 'badge' : 'badges' }}
               </SelectItem>
             </SelectContent>


### PR DESCRIPTION
## What

The free API **"Try it out"** card's ratings-limit (**"Max badges"**) dropdown only offered **0–8** badges. This bumps it to **0–10**.

```diff
-<SelectItem v-for="n in 9" :key="n - 1" :value="String(n - 1)">
+<SelectItem v-for="n in 11" :key="n - 1" :value="String(n - 1)">
```

## Why

10 is the real maximum everywhere else, and the free card had fallen behind:

- **Backend** — `validate_ratings_limit` allows `0..=10` (`api/src/services/db.rs`), commented as "one slot per available rating source."
- **Rating sources** — `ALL_RATING_SOURCES` now has **10** entries (imdb, tmdb, rt, rta, mc, trakt, lb, mal, mdblist, ebert).
- **Admin form** — `RenderSettingsForm.vue` already exposes the full range via `:max="10"`.

The free card's dropdown predates the 9th/10th sources, so users couldn't request more than 8 badges there even though the server accepts up to 10.

## Testing

- Added a regression test pinning the offered range at 0–10 (asserts `1 badge`/`9 badges`/`10 badges` present, `11 badges` absent). Verified it fails on the old `n in 9` and passes on `n in 11`.
- `npx vitest run` — all 25 files / 288 tests pass (the full CI frontend gate).