### PR TITLE
fix: re-apply per-type defaults when switching free-key image type

### DIFF
--- a/web/src/__tests__/components/FreeApiKeyCard.display.spec.ts
+++ b/web/src/__tests__/components/FreeApiKeyCard.display.spec.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { mount, flushPromises, VueWrapper } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import FreeApiKeyCard from '@/components/FreeApiKeyCard.vue'
+import { Select } from '@/components/ui/select'
+import { useAuthStore } from '@/stores/auth'
+import { DEFAULT_RATINGS_ORDER } from '@/lib/constants'
+import type { FreeKeyDefaults } from '@/lib/auth-api'
+
+/**
+ * These tests mount the card with the REAL reka-ui Select components (the rest
+ * of the suite stubs them). They guard the *displayed* trigger text, which has
+ * its own failure mode: reka-ui snapshots each option's text once when the item
+ * mounts, so a dynamic "default (resolved)" label that changes per image type
+ * would otherwise go stale on the closed trigger when switching poster<->backdrop
+ * (the control stays mounted, unlike logo which unmounts it).
+ */
+function makeDefaults(overrides: Partial<FreeKeyDefaults> = {}): FreeKeyDefaults {
+  return {
+    image_source: 't', lang: 'en', textless: false, ratings_limit: 3,
+    ratings_order: DEFAULT_RATINGS_ORDER, ratings_exclude: '',
+    poster_position: 'bc', logo_ratings_limit: 5, backdrop_ratings_limit: 5,
+    poster_badge_style: 'v', logo_badge_style: 'v', backdrop_badge_style: 'h',
+    poster_label_style: 'o', logo_label_style: 'o', backdrop_label_style: 'o',
+    poster_badge_direction: 'd', poster_badge_split: false,
+    poster_badge_size: 'm', logo_badge_size: 'm', backdrop_badge_size: 'm',
+    backdrop_position: 'tc', backdrop_badge_direction: 'd',
+    episode_ratings_limit: 3, episode_badge_style: 'v', episode_label_style: 'o',
+    episode_badge_size: 'm', episode_position: 'bc', episode_badge_direction: 'd',
+    episode_blur: false, ...overrides,
+  }
+}
+
+function mountReal(defaults: FreeKeyDefaults | null = makeDefaults()) {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  const auth = useAuthStore()
+  auth.freeApiKeyEnabled = true
+  if (defaults) auth.freeKeyDefaults = defaults
+  return mount(FreeApiKeyCard, {
+    global: {
+      plugins: [pinia],
+      // Keep Select real; only stub the collapsible wrapper + icons.
+      stubs: {
+        Collapsible: { template: '<div><slot /></div>', props: ['open'] },
+        CollapsibleTrigger: { template: '<div><slot /></div>', props: ['asChild'] },
+        CollapsibleContent: { template: '<div><slot /></div>' },
+        ChevronRight: { template: '<svg />' },
+        Loader2: { template: '<svg />' },
+      },
+    },
+  })
+}
+
+async function setSelect(wrapper: VueWrapper, triggerId: string, value: string) {
+  const parent = wrapper.findAllComponents(Select).find(s => s.find(`#${triggerId}`).exists())
+  if (!parent) throw new Error(`Select for #${triggerId} not found`)
+  parent.vm.$emit('update:modelValue', value)
+  await flushPromises()
+}
+
+const triggerText = (wrapper: VueWrapper, id: string) => wrapper.find(`#${id}`).text()
+
+describe('FreeApiKeyCard trigger display across image-type switches', () => {
+  afterEach(() => { vi.restoreAllMocks(); vi.unstubAllGlobals() })
+
+  it('clears a chosen position override from the trigger when switching type', async () => {
+    const wrapper = mountReal()
+    await flushPromises()
+    expect(triggerText(wrapper, 'free-image-position')).toBe('Position: default (Bottom Center)')
+
+    await setSelect(wrapper, 'free-image-position', 'tr')
+    expect(triggerText(wrapper, 'free-image-position')).toBe('Top Right')
+
+    // Switching to backdrop must drop the poster override (no longer "Top Right").
+    await setSelect(wrapper, 'free-image-type', 'backdrop')
+    expect(triggerText(wrapper, 'free-image-position')).not.toContain('Top Right')
+  })
+
+  it('updates the resolved default annotation per type (poster<->backdrop, no unmount)', async () => {
+    // backdrop_position=tc, poster_position=bc; the position control stays mounted
+    // across this switch, so this guards the reka-ui stale-text path specifically.
+    const wrapper = mountReal()
+    await flushPromises()
+    expect(triggerText(wrapper, 'free-image-position')).toBe('Position: default (Bottom Center)')
+
+    await setSelect(wrapper, 'free-image-type', 'backdrop')
+    expect(triggerText(wrapper, 'free-image-position')).toBe('Position: default (Top Center)')
+
+    await setSelect(wrapper, 'free-image-type', 'poster')
+    expect(triggerText(wrapper, 'free-image-position')).toBe('Position: default (Bottom Center)')
+  })
+
+  it('updates the badge-style default annotation per type', async () => {
+    // poster_badge_style=v (Vertical), backdrop_badge_style=h (Horizontal)
+    const wrapper = mountReal()
+    await flushPromises()
+    expect(triggerText(wrapper, 'free-badge-style')).toBe('Badge style: default (Vertical)')
+
+    await setSelect(wrapper, 'free-image-type', 'backdrop')
+    expect(triggerText(wrapper, 'free-badge-style')).toBe('Badge style: default (Horizontal)')
+  })
+
+  it('reflects the server default annotation once defaults load after mount', async () => {
+    // Mount with no defaults (null): the trigger shows the bare label. When the
+    // store resolves defaults, the keyed item re-registers and the annotation
+    // appears on the closed trigger without any user interaction.
+    const wrapper = mountReal(null)
+    await flushPromises()
+    expect(triggerText(wrapper, 'free-badge-style')).toBe('Badge style: default')
+
+    useAuthStore().freeKeyDefaults = makeDefaults({ poster_badge_style: 'h' })
+    await flushPromises()
+    expect(triggerText(wrapper, 'free-badge-style')).toBe('Badge style: default (Horizontal)')
+  })
+})

--- a/web/src/__tests__/components/FreeApiKeyCard.spec.ts
+++ b/web/src/__tests__/components/FreeApiKeyCard.spec.ts
@@ -296,6 +296,33 @@ describe('FreeApiKeyCard', () => {
     expect(findCurlCode(wrapper).text()).toContain('image_source=f')
   })
 
+  it('resets per-type render overrides when switching image type', async () => {
+    const wrapper = mountCard(true)
+
+    // Override poster's per-type render settings away from their defaults.
+    await setSelectById(wrapper, 'free-badge-style', 'h')
+    await setSelectById(wrapper, 'free-label-style', 't')
+    await setSelectById(wrapper, 'free-badge-size', 'l')
+    await setSelectById(wrapper, 'free-ratings-limit', '7')
+    // A global control (lang) that should survive the switch.
+    await setSelectById(wrapper, 'free-lang', 'en')
+    const posterCurl = findCurlCode(wrapper).text()
+    expect(posterCurl).toContain('badge_style=h')
+    expect(posterCurl).toContain('label_style=t')
+    expect(posterCurl).toContain('badge_size=l')
+    expect(posterCurl).toContain('ratings_limit=7')
+
+    // Switching type re-applies the new type's defaults: per-type overrides drop,
+    // the global lang persists.
+    await setSelectById(wrapper, 'free-image-type', 'backdrop')
+    const backdropCurl = findCurlCode(wrapper).text()
+    expect(backdropCurl).not.toContain('badge_style=')
+    expect(backdropCurl).not.toContain('label_style=')
+    expect(backdropCurl).not.toContain('badge_size=')
+    expect(backdropCurl).not.toContain('ratings_limit=')
+    expect(backdropCurl).toContain('lang=en')
+  })
+
   // --- Episode support ---
 
   it('episode queryString includes badge_direction, position, and blur', async () => {

--- a/web/src/components/FreeApiKeyCard.vue
+++ b/web/src/components/FreeApiKeyCard.vue
@@ -168,26 +168,32 @@ const blurDefaultLabel = computed(() =>
   defaults.value ? `Blur: default (${defaults.value.episode_blur ? 'Yes' : 'No'})` : 'Blur: default',
 )
 
-// Reset size when switching image type if the current size is invalid,
-// and reset poster-only controls when switching away from poster
+// Switching image type re-applies that type's own defaults: each type carries
+// its own server defaults (poster_badge_style vs logo_badge_style, etc.), so the
+// per-type render controls reset to "default" and the dropdowns reflect the new
+// type's settings rather than carrying over the previous type's overrides.
 watch(imageType, (newType) => {
   const validValues = sizeOptions.value.map(o => o.value)
   if (!validValues.includes(imageSize.value)) {
     imageSize.value = 'default'
   }
-  if (newType !== 'poster' && newType !== 'episode' && newType !== 'backdrop') {
-    badgeDirection.value = 'default'
-    imagePosition.value = 'default'
-  }
-  if (newType !== 'poster') {
-    textless.value = 'default'
-    posterSplit.value = 'default'
-  }
+  // Per-type render controls — reset on every switch so the form shows the
+  // appropriate defaults for the newly selected image type.
+  badgeStyle.value = 'default'
+  labelStyle.value = 'default'
+  badgeSize.value = 'default'
+  ratingsLimit.value = 'default'
+  badgeDirection.value = 'default'
+  imagePosition.value = 'default'
+  // Controls that only exist for one type; clearing them keeps the query string
+  // free of params the new type would ignore.
+  textless.value = 'default'
+  posterSplit.value = 'default'
+  blur.value = 'default'
+  // image_source is a single global default shared by every type, so it persists
+  // across switches — except episode, which doesn't accept the param.
   if (newType === 'episode') {
     imageSource.value = 'default'
-  }
-  if (newType !== 'episode') {
-    blur.value = 'default'
   }
 })
 

--- a/web/src/components/FreeApiKeyCard.vue
+++ b/web/src/components/FreeApiKeyCard.vue
@@ -289,6 +289,14 @@ async function handleFetch() {
       </CollapsibleTrigger>
       <CollapsibleContent class="pt-3 space-y-3">
       <form class="flex flex-col gap-3" @submit.prevent="handleFetch">
+        <!--
+          The dynamic "default (resolved)" items are :key'd by their label so
+          reka-ui re-registers the option's text when it changes — on a per-type
+          switch or when the server defaults load after mount. Without this the
+          closed trigger keeps the stale text reka-ui cached when the item first
+          mounted (it only snapshots textContent once), so the summary shown on
+          the trigger would lag the actual default for the selected image type.
+        -->
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
           <Select v-model="imageSize">
             <SelectTrigger id="free-image-size" aria-label="Image size" class="bg-background">
@@ -305,7 +313,7 @@ async function handleFetch() {
               <SelectValue placeholder="Language: any" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="any">{{ langDefaultLabel }}</SelectItem>
+              <SelectItem value="any" :key="langDefaultLabel">{{ langDefaultLabel }}</SelectItem>
               <SelectItem v-for="l in LANGUAGES" :key="l.code" :value="l.code">
                 {{ l.code }} - {{ l.name }}
               </SelectItem>
@@ -316,7 +324,7 @@ async function handleFetch() {
               <SelectValue placeholder="Max badges: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">{{ ratingsLimitDefaultLabel }}</SelectItem>
+              <SelectItem value="default" :key="ratingsLimitDefaultLabel">{{ ratingsLimitDefaultLabel }}</SelectItem>
               <SelectItem v-for="n in 11" :key="n - 1" :value="String(n - 1)">
                 {{ n - 1 }} {{ n - 1 === 1 ? 'badge' : 'badges' }}
               </SelectItem>
@@ -327,7 +335,7 @@ async function handleFetch() {
               <SelectValue placeholder="Badge style: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">{{ badgeStyleDefaultLabel }}</SelectItem>
+              <SelectItem value="default" :key="badgeStyleDefaultLabel">{{ badgeStyleDefaultLabel }}</SelectItem>
               <SelectItem value="h">Horizontal</SelectItem>
               <SelectItem value="v">Vertical</SelectItem>
             </SelectContent>
@@ -337,7 +345,7 @@ async function handleFetch() {
               <SelectValue placeholder="Label style: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">{{ labelStyleDefaultLabel }}</SelectItem>
+              <SelectItem value="default" :key="labelStyleDefaultLabel">{{ labelStyleDefaultLabel }}</SelectItem>
               <SelectItem value="t">Text</SelectItem>
               <SelectItem value="i">Icon</SelectItem>
               <SelectItem value="o">Official</SelectItem>
@@ -348,7 +356,7 @@ async function handleFetch() {
               <SelectValue placeholder="Badge size: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">{{ badgeSizeDefaultLabel }}</SelectItem>
+              <SelectItem value="default" :key="badgeSizeDefaultLabel">{{ badgeSizeDefaultLabel }}</SelectItem>
               <SelectItem value="xs">Extra Small</SelectItem>
               <SelectItem value="s">Small</SelectItem>
               <SelectItem value="m">Medium</SelectItem>
@@ -361,7 +369,7 @@ async function handleFetch() {
               <SelectValue placeholder="Source: default" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="default">{{ imageSourceDefaultLabel }}</SelectItem>
+              <SelectItem value="default" :key="imageSourceDefaultLabel">{{ imageSourceDefaultLabel }}</SelectItem>
               <SelectItem value="t">TMDB</SelectItem>
               <SelectItem value="f">Fanart.tv</SelectItem>
             </SelectContent>
@@ -372,7 +380,7 @@ async function handleFetch() {
                 <SelectValue placeholder="Textless: default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">{{ textlessDefaultLabel }}</SelectItem>
+                <SelectItem value="default" :key="textlessDefaultLabel">{{ textlessDefaultLabel }}</SelectItem>
                 <SelectItem value="true">Yes</SelectItem>
                 <SelectItem value="false">No</SelectItem>
               </SelectContent>
@@ -382,7 +390,7 @@ async function handleFetch() {
                 <SelectValue placeholder="Split badges: default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">{{ splitDefaultLabel }}</SelectItem>
+                <SelectItem value="default" :key="splitDefaultLabel">{{ splitDefaultLabel }}</SelectItem>
                 <SelectItem value="true">Yes</SelectItem>
                 <SelectItem value="false">No</SelectItem>
               </SelectContent>
@@ -394,7 +402,7 @@ async function handleFetch() {
                 <SelectValue placeholder="Position: default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">{{ positionDefaultLabel }}</SelectItem>
+                <SelectItem value="default" :key="positionDefaultLabel">{{ positionDefaultLabel }}</SelectItem>
                 <SelectItem value="bc">Bottom Center</SelectItem>
                 <SelectItem value="tc">Top Center</SelectItem>
                 <SelectItem value="l">Left</SelectItem>
@@ -410,7 +418,7 @@ async function handleFetch() {
                 <SelectValue placeholder="Direction: default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">{{ badgeDirectionDefaultLabel }}</SelectItem>
+                <SelectItem value="default" :key="badgeDirectionDefaultLabel">{{ badgeDirectionDefaultLabel }}</SelectItem>
                 <SelectItem value="h">Horizontal</SelectItem>
                 <SelectItem value="v">Vertical</SelectItem>
               </SelectContent>
@@ -422,7 +430,7 @@ async function handleFetch() {
                 <SelectValue placeholder="Blur: default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="default">{{ blurDefaultLabel }}</SelectItem>
+                <SelectItem value="default" :key="blurDefaultLabel">{{ blurDefaultLabel }}</SelectItem>
                 <SelectItem value="true">Yes</SelectItem>
                 <SelectItem value="false">No</SelectItem>
               </SelectContent>


### PR DESCRIPTION
## Problem

In the **Free API Key** card's *Try it out* form, switching the image type between **poster / logo / backdrop / episode** didn't correctly re-apply the settings for the newly selected type. Two distinct issues, both visible on the Position control:

1. **Stale selected value.** A render setting chosen for one type (e.g. Position = *Top Right*) carried over to the next type instead of resetting to that type's default. The form showed — and the generated `curl` emitted — the previous type's settings.
2. **Stale trigger text.** Even at the `default` value, the closed dropdown trigger showed the wrong *resolved* default after a switch. reka-ui snapshots each option's text once when the item mounts and never re-reads it, so the dynamic `default (resolved)` label went stale. This only surfaced on **poster↔backdrop** (the control stays mounted); switching to **logo** happened to look correct only because it unmounts/remounts the control. The same staleness also left the trigger without its `(resolved)` annotation after the server defaults loaded asynchronously post-mount.

## Fix

**1. Reset per-type controls on switch** (`watch(imageType, …)`): badge style, label style, badge size, max badges, position, and badge direction reset to `default` on every switch, so each re-resolves to the newly selected type's server default. Genuinely global controls persist: image source (a single global field with a type-invariant label), language, ratings order/exclude, and a still-valid image size. Type-only controls (`textless`/`split` for poster, `blur` for episode) are cleared too.

**2. Refresh the trigger text** by `:key`-ing each dynamic `default`/`any` `SelectItem` on its label. When the label changes — on a type switch or when defaults load — reka-ui re-registers the option's text, keeping the closed trigger's summary in sync with the selected type's defaults.

## Tests

- `FreeApiKeyCard.spec.ts`: added a regression test for the value reset (per-type params drop on switch while global `lang` persists).
- `FreeApiKeyCard.display.spec.ts` (new): mounts the **real** reka-ui selects (the rest of the suite stubs them) and asserts the trigger text — the chosen override clears on switch, the resolved-default annotation updates across poster↔backdrop, and the annotation appears once defaults load post-mount.
- Full unit suite green (293 tests) and production build clean.