### PR TITLE
fix: keep ratings for anime/IMDb-less titles via MDBList TMDB fallback (#14)

### DIFF
--- a/api/src/services/mdblist.rs
+++ b/api/src/services/mdblist.rs
@@ -38,27 +38,41 @@ pub struct MdblistRating {
     pub votes: Option<i64>,
 }
 
+/// MDBList path segment for a media type. Movies are `movie`, series are `show`.
+/// Episodes are unsupported — MDBList only has movie/show-level ratings.
+fn mdblist_kind(media_type: &MediaType) -> Result<&'static str, AppError> {
+    match media_type {
+        MediaType::Movie => Ok("movie"),
+        MediaType::Tv => Ok("show"),
+        MediaType::Episode => Err(AppError::Other("mdblist does not support episode ratings".into())),
+    }
+}
+
+/// Build the MDBList ratings URL for an IMDb-keyed lookup.
+fn imdb_ratings_url(kind: &str, imdb_id: &str) -> String {
+    format!("https://api.mdblist.com/imdb/{kind}/{imdb_id}")
+}
+
+/// Build the MDBList ratings URL for a TMDB-keyed lookup.
+///
+/// Used as a fallback for titles (notably anime) that TMDB knows but hasn't
+/// cross-referenced to IMDb. The TMDB endpoint returns the same full rating set
+/// as the IMDb endpoint — including MyAnimeList — so titles with no IMDb id keep
+/// their badges instead of collapsing to the TMDB vote_average alone. (issue #14)
+fn tmdb_ratings_url(kind: &str, tmdb_id: u64) -> String {
+    format!("https://api.mdblist.com/tmdb/{kind}/{tmdb_id}")
+}
+
 impl MdblistClient {
     pub fn new(api_key: String, http: reqwest::Client) -> Self {
         Self { api_key: Arc::new(Zeroizing::new(api_key)), http }
     }
 
-    pub async fn get_ratings(
-        &self,
-        imdb_id: &str,
-        media_type: &MediaType,
-    ) -> Result<MdblistResponse, AppError> {
-        let kind = match media_type {
-            MediaType::Movie => "movie",
-            MediaType::Tv => "show",
-            MediaType::Episode => return Err(AppError::Other("mdblist does not support episode ratings".into())),
-        };
-
-        let url = format!("https://api.mdblist.com/imdb/{kind}/{imdb_id}");
-
+    /// Fetch and deserialize an MDBList ratings response from a fully-built URL.
+    async fn fetch(&self, url: &str) -> Result<MdblistResponse, AppError> {
         let resp = retry::send_with_retry(&MDBLIST_RETRY, || {
             self.http
-                .get(&url)
+                .get(url)
                 .query(&[("apikey", self.api_key.as_str())])
                 .send()
         })
@@ -66,5 +80,55 @@ impl MdblistClient {
         .error_for_status()?;
 
         Ok(resp.json().await?)
+    }
+
+    /// Fetch ratings keyed by IMDb id.
+    pub async fn get_ratings(
+        &self,
+        imdb_id: &str,
+        media_type: &MediaType,
+    ) -> Result<MdblistResponse, AppError> {
+        let kind = mdblist_kind(media_type)?;
+        self.fetch(&imdb_ratings_url(kind, imdb_id)).await
+    }
+
+    /// Fetch ratings keyed by TMDB id. Used when a title has no IMDb id so the
+    /// IMDb-keyed endpoint can't be reached (issue #14).
+    pub async fn get_ratings_by_tmdb(
+        &self,
+        tmdb_id: u64,
+        media_type: &MediaType,
+    ) -> Result<MdblistResponse, AppError> {
+        let kind = mdblist_kind(media_type)?;
+        self.fetch(&tmdb_ratings_url(kind, tmdb_id)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mdblist_kind_maps_movie_and_tv() {
+        assert_eq!(mdblist_kind(&MediaType::Movie).unwrap(), "movie");
+        assert_eq!(mdblist_kind(&MediaType::Tv).unwrap(), "show");
+    }
+
+    #[test]
+    fn mdblist_kind_rejects_episode() {
+        assert!(mdblist_kind(&MediaType::Episode).is_err());
+    }
+
+    #[test]
+    fn imdb_ratings_url_format() {
+        assert_eq!(imdb_ratings_url("show", "tt2560140"), "https://api.mdblist.com/imdb/show/tt2560140");
+        assert_eq!(imdb_ratings_url("movie", "tt0111161"), "https://api.mdblist.com/imdb/movie/tt0111161");
+    }
+
+    #[test]
+    fn tmdb_ratings_url_format() {
+        // The TMDB fallback endpoint that restores ratings for IMDb-less titles.
+        assert_eq!(tmdb_ratings_url("show", 1429), "https://api.mdblist.com/tmdb/show/1429");
+        assert_eq!(tmdb_ratings_url("movie", 550), "https://api.mdblist.com/tmdb/movie/550");
     }
 }

--- a/api/src/services/ratings.rs
+++ b/api/src/services/ratings.rs
@@ -1055,25 +1055,97 @@ mod tests {
         assert!(mdblist_badges(&resp).is_empty());
     }
 
+    // --- mdblist_lookup_for (issue #14) ---
+
+    fn resolved(imdb: Option<&str>, tmdb_id: u64, media_type: MediaType) -> ResolvedId {
+        ResolvedId {
+            imdb_id: imdb.map(|s| s.to_string()),
+            tmdb_id,
+            tvdb_id: None,
+            media_type,
+            poster_path: None,
+            release_date: None,
+            episode: None,
+        }
+    }
+
+    #[test]
+    fn mdblist_lookup_prefers_imdb_when_present() {
+        let r = resolved(Some("tt2560140"), 1429, MediaType::Tv);
+        assert_eq!(mdblist_lookup_for(&r), Some(MdblistLookup::Imdb("tt2560140")));
+    }
+
+    #[test]
+    fn mdblist_lookup_falls_back_to_tmdb_when_no_imdb() {
+        // The anime case: TMDB knows the title but has no IMDb cross-reference.
+        // Without the fallback, every MDBList-sourced badge (incl. MAL) is lost.
+        let r = resolved(None, 1429, MediaType::Tv);
+        assert_eq!(mdblist_lookup_for(&r), Some(MdblistLookup::Tmdb(1429)));
+    }
+
+    #[test]
+    fn mdblist_lookup_falls_back_to_tmdb_for_movies_too() {
+        let r = resolved(None, 550, MediaType::Movie);
+        assert_eq!(mdblist_lookup_for(&r), Some(MdblistLookup::Tmdb(550)));
+    }
+
+    #[test]
+    fn mdblist_lookup_none_for_episodes() {
+        // MDBList has no episode-level ratings regardless of which ids are present.
+        let with_imdb = resolved(Some("tt2560140"), 1429, MediaType::Episode);
+        let without_imdb = resolved(None, 1429, MediaType::Episode);
+        assert_eq!(mdblist_lookup_for(&with_imdb), None);
+        assert_eq!(mdblist_lookup_for(&without_imdb), None);
+    }
+
+}
+
+/// Which MDBList endpoint to use for a resolved title.
+///
+/// Prefer the IMDb-keyed lookup. When a title resolved without an IMDb id —
+/// common for anime and other titles TMDB knows but hasn't cross-referenced to
+/// IMDb — fall back to the TMDB id (always present), so the title keeps every
+/// MDBList-sourced badge (IMDb, RT, Metacritic, Trakt, Letterboxd, MyAnimeList,
+/// the MDBList score, Roger Ebert) instead of collapsing to the TMDB
+/// vote_average alone. Episodes have no MDBList ratings. (issue #14)
+#[derive(Debug, PartialEq, Eq)]
+enum MdblistLookup<'a> {
+    Imdb(&'a str),
+    Tmdb(u64),
+}
+
+fn mdblist_lookup_for(resolved: &ResolvedId) -> Option<MdblistLookup<'_>> {
+    // mdblist only supports movie/show level ratings, not individual episodes
+    if resolved.media_type == MediaType::Episode {
+        return None;
+    }
+    match resolved.imdb_id.as_deref() {
+        Some(imdb_id) => Some(MdblistLookup::Imdb(imdb_id)),
+        None => Some(MdblistLookup::Tmdb(resolved.tmdb_id)),
+    }
 }
 
 async fn fetch_mdblist_ratings(
     resolved: &ResolvedId,
     mdblist: Option<&MdblistClient>,
 ) -> Option<(Vec<RatingBadge>, Option<u64>, Option<u64>, Option<String>)> {
-    // mdblist only supports movie/show level ratings, not individual episodes
-    if resolved.media_type == MediaType::Episode {
-        return None;
-    }
     let client = mdblist?;
-    let imdb_id = resolved.imdb_id.as_deref()?;
 
-    let resp = match client.get_ratings(imdb_id, &resolved.media_type).await {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!(imdb_id, media_type = ?resolved.media_type, "mdblist rating fetch failed: {e}");
-            return None;
-        }
+    let resp = match mdblist_lookup_for(resolved)? {
+        MdblistLookup::Imdb(imdb_id) => match client.get_ratings(imdb_id, &resolved.media_type).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(imdb_id, media_type = ?resolved.media_type, "mdblist rating fetch failed: {e}");
+                return None;
+            }
+        },
+        MdblistLookup::Tmdb(tmdb_id) => match client.get_ratings_by_tmdb(tmdb_id, &resolved.media_type).await {
+            Ok(r) => r,
+            Err(e) => {
+                tracing::warn!(tmdb_id, media_type = ?resolved.media_type, "mdblist tmdb rating fetch failed: {e}");
+                return None;
+            }
+        },
     };
 
     Some((mdblist_badges(&resp), resp.ids.tmdb, resp.ids.tvdb, resp.ids.imdb))


### PR DESCRIPTION
Closes #14.

## The report
A user reported anime seasons not getting ratings correctly ([r/StremioAddons thread](https://www.reddit.com/r/StremioAddons/comments/1rxobsl/comment/obxb51u/)). The issue suspected anime being split into per-season entries.

## Root cause
I traced the request → resolve → ratings flow and confirmed it against the live TMDB/MDBList APIs and the aiometadata/RPDB source.

Every rating source **except TMDB's own `vote_average`** is looked up through MDBList, which the code only ever called by **IMDb id** (`https://api.mdblist.com/imdb/{movie|show}/{imdb_id}`). OMDb and Trakt are IMDb-keyed too. So `fetch_mdblist_ratings` bailed out the moment a title resolved with no `imdb_id`:

```rust
let imdb_id = resolved.imdb_id.as_deref()?;   // None → return early → TMDB-score-only
```

Anime split into per-season entries (Kitsu/MAL-sourced) routinely resolve to a TMDB id with **no IMDb cross-reference**, so they dropped to the TMDB score alone — losing IMDb, RT, Metacritic, Trakt, Letterboxd, **MyAnimeList**, the MDBList score, and Roger Ebert.

Verified live: `https://api.mdblist.com/tmdb/{movie|show}/{tmdb_id}` returns the **same full rating set including `myanimelist`** as the IMDb endpoint, and `resolved.tmdb_id` is always present.

## The fix
Add a TMDB-keyed MDBList lookup (`get_ratings_by_tmdb`) and use it as a **fallback in `fetch_mdblist_ratings` only when `resolved.imdb_id` is `None`**. Small, targeted, no new id type, no extra calls for titles that already have an IMDb id. MDBList also returns `ids.imdb` in the response, which is already used to backfill the cross-id cache, so cross-id caching keeps working.

- `mdblist.rs`: extract a shared `fetch(url)` helper + pure `mdblist_kind`/URL builders; add `get_ratings_by_tmdb`.
- `ratings.rs`: extract `mdblist_lookup_for(resolved)` (IMDb-preferred, TMDB fallback, `None` for episodes) and dispatch on it.

## Scope / limitation (per-season accuracy is *not* in this PR)
MAL scores anime **per season** (e.g. Attack on Titan S1/S2/S3/S4 each have a different MAL entry and score), but the id that reaches the poster service is **always series-level** — aiometadata and RPDB never encode a season number in the poster URL. A single series id cannot distinguish seasons, so this PR restores the (series-level) rating set rather than making MAL per-season-correct. RPDB (which OpenPosterDB replaces) has the same limitation. True per-season ratings would require a season-aware id type (mal/kitsu) and upstream cooperation — worth a separate tracking issue if desired.

## Testing
- New unit tests: `mdblist_kind`, IMDb/TMDB URL builders, and `mdblist_lookup_for` (IMDb-present, IMDb-absent→TMDB for shows and movies, episodes→None).
- `cargo test` — full backend suite green (442 lib + all integration tests).
- `cargo clippy` — no new warnings (warning count identical to `main`).