### PR TITLE
Support normalizing poster aspect ratio to 2:3 (#15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,10 @@ GET /{api_key}/isValid
 - `?textless={true|false}`: prefer textless images when available (poster only). Works with both TMDB and Fanart.tv sources
 - `?blur={true|false}`: apply Gaussian blur for spoiler protection (episode only). Badges remain sharp over the blurred still image
 - `?split={true|false}`: split the badges evenly across two opposite sides of the poster (poster only). The axis follows the badge layout — a vertical layout splits left/right, horizontal rows split top/bottom. With an odd number of badges the configured side gets the extra one (e.g. 4 badges → 2 + 2, 3 badges → 2 + 1)
+- `?fit={native|cover|pad|blur}`: how a non-2:3 source poster is fit to the standard 2:3 output frame (poster only). `cover` (default) scales to fill 2:3 and center-crops the overflow; `pad` fits the whole poster inside 2:3 with solid black bars; `blur` fits the whole poster inside 2:3 and fills the bars with a blurred, zoomed copy of the poster; `native` keeps the source aspect ratio (legacy behavior). The non-native modes guarantee a uniform 2:3 image so downstream apps that place posters in fixed 2:3 containers don't crop the art
 - RPDB-compatible — use `http://localhost:3000` as the base URL (drop-in replacement for `https://api.ratingposterdb.com`). Old parameter names `?poster_source=` and `?fanart_textless=` are accepted as aliases
 
-`textless` and `split` are poster-only. `blur` is episode-only. `badge_direction` and `position` are silently ignored on logo endpoints. For shared parameters (`ratings_limit`, `badge_style`, `label_style`, `badge_size`, `badge_shape`, `badge_background`, `image_source`), the override is applied to the correct image-type-specific setting (e.g. `?badge_style=h` on the poster endpoint sets `poster_badge_style`, on the logo endpoint sets `logo_badge_style`).
+`textless`, `split`, and `fit` are poster-only. `blur` is episode-only. `badge_direction` and `position` are silently ignored on logo endpoints. For shared parameters (`ratings_limit`, `badge_style`, `label_style`, `badge_size`, `badge_shape`, `badge_background`, `image_source`), the override is applied to the correct image-type-specific setting (e.g. `?badge_style=h` on the poster endpoint sets `poster_badge_style`, on the logo endpoint sets `logo_badge_style`).
 
 Management endpoints (auth, keys, settings) are under `/api/` and return JSON.
 
@@ -150,9 +151,11 @@ The `?imageSize=` parameter controls the output dimensions. When omitted, `mediu
 
 | Size | Dimensions |
 |---|---|
-| `medium` *(default)* | 580 × 859 |
-| `large` | 1280 × 1896 |
-| `very-large` / `verylarge` | 2000 × 2962 |
+| `medium` *(default)* | 580 × 870 |
+| `large` | 1280 × 1920 |
+| `very-large` / `verylarge` | 2000 × 3000 |
+
+Dimensions are the standard 2:3 poster ratio produced by the default `cover` fit (and the `pad`/`blur` fits). With `?fit=native` the output keeps the source poster's aspect ratio, so the height varies.
 
 **Logo sizes:**
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ GET /{api_key}/isValid
 - `?textless={true|false}`: prefer textless images when available (poster only). Works with both TMDB and Fanart.tv sources
 - `?blur={true|false}`: apply Gaussian blur for spoiler protection (episode only). Badges remain sharp over the blurred still image
 - `?split={true|false}`: split the badges evenly across two opposite sides of the poster (poster only). The axis follows the badge layout — a vertical layout splits left/right, horizontal rows split top/bottom. With an odd number of badges the configured side gets the extra one (e.g. 4 badges → 2 + 2, 3 badges → 2 + 1)
-- `?fit={native|cover|pad|blur}`: how a non-2:3 source poster is fit to the standard 2:3 output frame (poster only). `cover` (default) scales to fill 2:3 and center-crops the overflow; `pad` fits the whole poster inside 2:3 with solid black bars; `blur` fits the whole poster inside 2:3 and fills the bars with a blurred, zoomed copy of the poster; `native` keeps the source aspect ratio (legacy behavior). The non-native modes guarantee a uniform 2:3 image so downstream apps that place posters in fixed 2:3 containers don't crop the art
+- `?fit={native|cover|pad|blur}`: how a poster is fit to the standard 2:3 output frame (poster only). `native` (default) keeps the source aspect ratio; `cover` scales to fill 2:3 and center-crops the overflow; `pad` fits the whole poster inside 2:3 with solid black bars; `blur` fits the whole poster inside 2:3 and fills the bars with a blurred, zoomed copy of the poster. The non-native modes guarantee a uniform 2:3 image so downstream apps that place posters in fixed 2:3 containers don't crop the art
 - RPDB-compatible — use `http://localhost:3000` as the base URL (drop-in replacement for `https://api.ratingposterdb.com`). Old parameter names `?poster_source=` and `?fanart_textless=` are accepted as aliases
 
 `textless`, `split`, and `fit` are poster-only. `blur` is episode-only. `badge_direction` and `position` are silently ignored on logo endpoints. For shared parameters (`ratings_limit`, `badge_style`, `label_style`, `badge_size`, `badge_shape`, `badge_background`, `image_source`), the override is applied to the correct image-type-specific setting (e.g. `?badge_style=h` on the poster endpoint sets `poster_badge_style`, on the logo endpoint sets `logo_badge_style`).
@@ -151,11 +151,11 @@ The `?imageSize=` parameter controls the output dimensions. When omitted, `mediu
 
 | Size | Dimensions |
 |---|---|
-| `medium` *(default)* | 580 × 870 |
-| `large` | 1280 × 1920 |
-| `very-large` / `verylarge` | 2000 × 3000 |
+| `medium` *(default)* | 580 × 859 |
+| `large` | 1280 × 1896 |
+| `very-large` / `verylarge` | 2000 × 2962 |
 
-Dimensions are the standard 2:3 poster ratio produced by the default `cover` fit (and the `pad`/`blur` fits). With `?fit=native` the output keeps the source poster's aspect ratio, so the height varies.
+Heights are representative for a standard ~2:3 source under the default `native` fit, which preserves the source aspect ratio (so the exact height varies per poster). The `cover`, `pad`, and `blur` fits instead produce an exact 2:3 frame (580 × 870, 1280 × 1920, 2000 × 3000).
 
 **Logo sizes:**
 

--- a/api/src/entity/api_key_settings.rs
+++ b/api/src/entity/api_key_settings.rs
@@ -21,6 +21,7 @@ pub struct Model {
     pub backdrop_label_style: String,
     pub poster_badge_direction: String,
     pub poster_badge_split: bool,
+    pub poster_fit: String,
     pub poster_badge_size: String,
     pub logo_badge_size: String,
     pub backdrop_badge_size: String,

--- a/api/src/handlers/admin.rs
+++ b/api/src/handlers/admin.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::cache;
 use crate::error::AppError;
 use crate::image::serve::{self, LogoBackdropKind};
-use crate::services::db::{self, default_ratings_limit, default_logo_backdrop_ratings_limit, default_ratings_order, BadgeBackground, BadgeDirection, BadgeShape, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, ImageSource};
+use crate::services::db::{self, default_ratings_limit, default_logo_backdrop_ratings_limit, default_ratings_order, BadgeBackground, BadgeDirection, BadgeShape, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, ImageSource, PosterFit};
 use crate::AppState;
 
 #[derive(Serialize)]
@@ -130,6 +130,7 @@ pub struct GlobalSettingsResponse {
     pub backdrop_label_style: LabelStyle,
     pub poster_badge_direction: BadgeDirection,
     pub poster_badge_split: bool,
+    pub poster_fit: PosterFit,
     pub poster_badge_size: BadgeSize,
     pub logo_badge_size: BadgeSize,
     pub backdrop_badge_size: BadgeSize,
@@ -187,6 +188,7 @@ pub async fn get_settings(
         backdrop_label_style: settings.backdrop_label_style,
         poster_badge_direction: settings.poster_badge_direction,
         poster_badge_split: settings.poster_badge_split,
+        poster_fit: settings.poster_fit,
         poster_badge_size: settings.poster_badge_size,
         logo_badge_size: settings.logo_badge_size,
         backdrop_badge_size: settings.backdrop_badge_size,
@@ -247,6 +249,8 @@ pub struct UpdateGlobalSettingsRequest {
     pub poster_badge_direction: BadgeDirection,
     #[serde(default)]
     pub poster_badge_split: bool,
+    #[serde(default = "db::default_poster_fit")]
+    pub poster_fit: PosterFit,
     #[serde(default = "db::default_badge_size")]
     pub poster_badge_size: BadgeSize,
     #[serde(default = "db::default_badge_size")]
@@ -319,6 +323,7 @@ pub async fn update_settings(
         ("backdrop_label_style", req.backdrop_label_style.as_str()),
         ("poster_badge_direction", req.poster_badge_direction.as_str()),
         ("poster_badge_split", poster_badge_split_str),
+        ("poster_fit", req.poster_fit.as_str()),
         ("poster_badge_size", req.poster_badge_size.as_str()),
         ("logo_badge_size", req.logo_badge_size.as_str()),
         ("backdrop_badge_size", req.backdrop_badge_size.as_str()),

--- a/api/src/handlers/api_keys.rs
+++ b/api/src/handlers/api_keys.rs
@@ -10,7 +10,7 @@ use sha2::{Digest, Sha256};
 use super::auth::AuthUser;
 use super::middleware::ApiKeyUser;
 use crate::error::AppError;
-use crate::services::db::{self, default_ratings_limit, default_logo_backdrop_ratings_limit, default_ratings_order, BadgeBackground, BadgeDirection, BadgeShape, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, ImageSource};
+use crate::services::db::{self, default_ratings_limit, default_logo_backdrop_ratings_limit, default_ratings_order, BadgeBackground, BadgeDirection, BadgeShape, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, ImageSource, PosterFit};
 use crate::services::validation;
 use crate::AppState;
 
@@ -112,6 +112,7 @@ pub struct RenderSettingsResponse {
     pub backdrop_label_style: LabelStyle,
     pub poster_badge_direction: BadgeDirection,
     pub poster_badge_split: bool,
+    pub poster_fit: PosterFit,
     pub poster_badge_size: BadgeSize,
     pub logo_badge_size: BadgeSize,
     pub backdrop_badge_size: BadgeSize,
@@ -166,6 +167,7 @@ fn settings_to_response(settings: &db::RenderSettings, fanart_available: bool) -
         backdrop_label_style: settings.backdrop_label_style,
         poster_badge_direction: settings.poster_badge_direction,
         poster_badge_split: settings.poster_badge_split,
+        poster_fit: settings.poster_fit,
         poster_badge_size: settings.poster_badge_size,
         logo_badge_size: settings.logo_badge_size,
         backdrop_badge_size: settings.backdrop_badge_size,
@@ -225,6 +227,8 @@ pub struct UpdateSettingsRequest {
     pub poster_badge_direction: BadgeDirection,
     #[serde(default)]
     pub poster_badge_split: bool,
+    #[serde(default = "db::default_poster_fit")]
+    pub poster_fit: PosterFit,
     #[serde(default = "db::default_badge_size")]
     pub poster_badge_size: BadgeSize,
     #[serde(default = "db::default_badge_size")]
@@ -287,6 +291,7 @@ fn build_upsert(id: i32, req: &UpdateSettingsRequest) -> db::UpsertApiKeySetting
         backdrop_label_style: req.backdrop_label_style.as_str(),
         poster_badge_direction: req.poster_badge_direction.as_str(),
         poster_badge_split: req.poster_badge_split,
+        poster_fit: req.poster_fit.as_str(),
         poster_badge_size: req.poster_badge_size.as_str(),
         logo_badge_size: req.logo_badge_size.as_str(),
         backdrop_badge_size: req.backdrop_badge_size.as_str(),

--- a/api/src/handlers/image.rs
+++ b/api/src/handlers/image.rs
@@ -12,7 +12,7 @@ use crate::image::serve;
 use crate::services::db;
 use crate::services::db::{
     BadgeBackground, BadgeDirection, BadgeShape, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, ImageSource,
-    RenderSettings,
+    PosterFit, RenderSettings,
 };
 use crate::AppState;
 
@@ -114,6 +114,10 @@ pub struct ImageQuery {
     #[serde(default)]
     #[param(value_type = Option<bool>)]
     pub split: Option<bool>,
+    /// Poster fit to the 2:3 frame (poster only): `native`, `cover`, `pad`, `blur`.
+    #[serde(default)]
+    #[param(value_type = Option<String>)]
+    pub fit: Option<PosterFit>,
 }
 
 impl ImageQuery {
@@ -133,6 +137,7 @@ impl ImageQuery {
             || self.textless.is_some()
             || self.blur.is_some()
             || self.split.is_some()
+            || self.fit.is_some()
     }
 }
 
@@ -182,6 +187,7 @@ pub struct FreeKeySettingsResponse {
     pub backdrop_label_style: LabelStyle,
     pub poster_badge_direction: BadgeDirection,
     pub poster_badge_split: bool,
+    pub poster_fit: PosterFit,
     pub poster_badge_size: BadgeSize,
     pub logo_badge_size: BadgeSize,
     pub backdrop_badge_size: BadgeSize,
@@ -224,6 +230,7 @@ impl From<&RenderSettings> for FreeKeySettingsResponse {
             backdrop_label_style: s.backdrop_label_style,
             poster_badge_direction: s.poster_badge_direction,
             poster_badge_split: s.poster_badge_split,
+            poster_fit: s.poster_fit,
             poster_badge_size: s.poster_badge_size,
             logo_badge_size: s.logo_badge_size,
             backdrop_badge_size: s.backdrop_badge_size,
@@ -432,6 +439,9 @@ fn apply_query_overrides(
         }
         if let Some(split) = query.split {
             s.poster_badge_split = split;
+        }
+        if let Some(fit) = query.fit {
+            s.poster_fit = fit;
         }
     }
     if kind == cache::ImageType::Backdrop {
@@ -865,6 +875,7 @@ mod tests {
             textless: None,
             blur: None,
             split: None,
+            fit: None,
         }
     }
 
@@ -892,6 +903,7 @@ mod tests {
             ratings_order: Some("imdb,tmdb".into()),
             ratings_exclude: Some("rt".into()),
             split: Some(true),
+            fit: Some(PosterFit::Pad),
             ..empty_query()
         };
         let result =
@@ -904,6 +916,7 @@ mod tests {
         assert_eq!(result.poster_badge_direction, BadgeDirection::Horizontal);
         assert_eq!(result.poster_position, BadgePosition::TopLeft);
         assert_eq!(result.image_source, ImageSource::Fanart);
+        assert_eq!(result.poster_fit, PosterFit::Pad);
         assert!(result.textless);
         assert!(result.poster_badge_split);
         assert_eq!(&*result.ratings_order, "imdb,tmdb");

--- a/api/src/handlers/preview.rs
+++ b/api/src/handlers/preview.rs
@@ -200,9 +200,11 @@ pub async fn preview_poster(
     let badge_style = raw_badge_style.resolve(badge_direction);
     let badge_appearance = preview_badge_appearance(&query);
     let split = query.split.unwrap_or(false);
+    let poster_fit = query.fit.unwrap_or_else(db::default_poster_fit);
     let ratings_suffix = ratings::ratings_cache_suffix(ratings_order, ratings_exclude, ratings_limit);
     let mut preview_settings = preview_render_settings(cache::ImageType::Poster, badge_style, label_style, badge_size, position, badge_direction, badge_appearance, ratings_limit, ratings_order, ratings_exclude);
     preview_settings.poster_badge_split = split;
+    preview_settings.poster_fit = poster_fit;
     let suffix = serve::settings_cache_suffix_with_ratings(&preview_settings, cache::ImageType::Poster, image_size, &ratings_suffix);
     let cache_key = format!("preview:{suffix}");
     let cache_path = cache::preview_path(&state.config.cache_dir, cache::ImageType::Poster, &suffix, "jpg")?;
@@ -227,7 +229,7 @@ pub async fn preview_poster(
     let font = state.font.clone();
     let quality = state.config.image_quality;
     let buf = tokio::task::spawn_blocking(move || {
-        generate::render_poster_sync(poster_png, &badges, &font, quality, position, badge_style, label_style, badge_appearance, badge_direction, target_width, badge_scale, badge_size, split)
+        generate::render_poster_sync(poster_png, &badges, &font, quality, position, badge_style, label_style, badge_appearance, badge_direction, target_width, badge_scale, badge_size, split, poster_fit)
     })
     .await
     .map_err(|e| AppError::Other(e.to_string()))??;
@@ -489,7 +491,7 @@ mod tests {
     fn sample_poster_renders_with_badges() {
         let font = ab_glyph::FontArc::try_from_slice(crate::FONT_BYTES).unwrap();
         let badges = sample_badges();
-        let result = generate::render_poster_sync(&SAMPLE_POSTER_PNG, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false);
+        let result = generate::render_poster_sync(&SAMPLE_POSTER_PNG, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, db::PosterFit::Native);
         let buf = result.expect("rendering should succeed");
         // Valid JPEG
         assert_eq!(buf[0], 0xFF);
@@ -500,7 +502,7 @@ mod tests {
     #[test]
     fn sample_poster_renders_with_no_badges() {
         let font = ab_glyph::FontArc::try_from_slice(crate::FONT_BYTES).unwrap();
-        let result = generate::render_poster_sync(&SAMPLE_POSTER_PNG, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false);
+        let result = generate::render_poster_sync(&SAMPLE_POSTER_PNG, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, db::PosterFit::Native);
         let buf = result.expect("rendering should succeed");
         assert_eq!(buf[0], 0xFF);
         assert_eq!(buf[1], 0xD8);

--- a/api/src/image/generate.rs
+++ b/api/src/image/generate.rs
@@ -8,7 +8,7 @@ use tokio::sync::Semaphore;
 use crate::cache;
 use crate::error::AppError;
 use crate::image::badge;
-use crate::services::db::{BadgeAppearance, BadgeDirection, BadgeSize, BadgeStyle, LabelStyle, BadgePosition};
+use crate::services::db::{BadgeAppearance, BadgeDirection, BadgeSize, BadgeStyle, LabelStyle, BadgePosition, PosterFit};
 use crate::services::ratings::RatingBadge;
 use crate::services::tmdb::TmdbClient;
 
@@ -42,6 +42,8 @@ pub struct ImageParams<'a> {
     pub badge_direction: BadgeDirection,
     /// When true, split the badges across two opposite sides of the poster.
     pub poster_badge_split: bool,
+    /// How a non-2:3 poster is fit to the standard 2:3 output frame.
+    pub poster_fit: PosterFit,
     pub render_semaphore: Arc<Semaphore>,
     /// Target width for the output image. Defaults to 500 for posters.
     pub target_width: u32,
@@ -71,6 +73,7 @@ pub async fn generate_poster(params: ImageParams<'_>) -> Result<Vec<u8>, AppErro
         badge_appearance,
         badge_direction,
         poster_badge_split,
+        poster_fit,
         render_semaphore,
         target_width,
         badge_scale,
@@ -129,7 +132,7 @@ pub async fn generate_poster(params: ImageParams<'_>) -> Result<Vec<u8>, AppErro
     let badges = badges.to_vec();
     let font = font.clone();
     let buf = tokio::task::spawn_blocking(move || {
-        render_poster_sync(&poster_bytes, &badges, &font, quality, poster_position, badge_style, label_style, badge_appearance, badge_direction, target_width, badge_scale, badge_size, poster_badge_split)
+        render_poster_sync(&poster_bytes, &badges, &font, quality, poster_position, badge_style, label_style, badge_appearance, badge_direction, target_width, badge_scale, badge_size, poster_badge_split, poster_fit)
     })
     .await
     .map_err(|e| AppError::Other(e.to_string()))??;
@@ -263,6 +266,67 @@ fn load_image_with_limits(bytes: &[u8]) -> Result<image::DynamicImage, AppError>
     image::DynamicImage::from_decoder(decoder).map_err(AppError::Image)
 }
 
+/// Standard movie-poster aspect ratio is 2:3 (width:height), so the output
+/// height for a given width is `width * 3 / 2`.
+fn poster_target_height(target_width: u32) -> u32 {
+    ((target_width as f64) * 1.5).round() as u32
+}
+
+/// Blur strength for `PosterFit::Blur` scales with output width so the effect
+/// looks consistent across image sizes. `fast_blur` approximates a Gaussian
+/// blur cheaply enough for the largest (2000px) posters.
+const BLUR_SIGMA_DIVISOR: f32 = 32.0;
+
+/// Normalize a decoded source poster to the output frame per `fit`, returning
+/// the RGBA canvas the badges are then composited onto.
+///
+/// Every mode except `Native` produces an exact 2:3 frame
+/// (`target_width × target_width*3/2`) so downstream apps that place posters in
+/// fixed 2:3 containers never crop the art (issue #15).
+fn fit_poster(base: DynamicImage, target_width: u32, fit: PosterFit) -> RgbaImage {
+    use image::imageops::FilterType::Lanczos3;
+    match fit {
+        // Preserve the source aspect ratio: scale to target_width only.
+        PosterFit::Native => {
+            if base.width() == target_width {
+                base.to_rgba8()
+            } else {
+                let scale = target_width as f64 / base.width() as f64;
+                let target_height = ((base.height() as f64 * scale).round() as u32).max(1);
+                base.resize_exact(target_width, target_height, Lanczos3).to_rgba8()
+            }
+        }
+        // Scale to fill the 2:3 frame, center-cropping the overflow.
+        PosterFit::Cover => {
+            let th = poster_target_height(target_width);
+            base.resize_to_fill(target_width, th, Lanczos3).to_rgba8()
+        }
+        // Fit the whole poster inside 2:3, padding with solid black bars.
+        PosterFit::Pad => {
+            let th = poster_target_height(target_width);
+            let fitted = base.resize(target_width, th, Lanczos3).to_rgba8();
+            let mut canvas = RgbaImage::from_pixel(target_width, th, image::Rgba([0, 0, 0, 255]));
+            let x = ((target_width.saturating_sub(fitted.width())) / 2) as i64;
+            let y = ((th.saturating_sub(fitted.height())) / 2) as i64;
+            imageops::overlay(&mut canvas, &fitted, x, y);
+            canvas
+        }
+        // Fit the whole poster inside 2:3, filling the bars with a blurred,
+        // zoomed copy of the poster.
+        PosterFit::Blur => {
+            let th = poster_target_height(target_width);
+            let bg = base.resize_to_fill(target_width, th, Lanczos3).to_rgba8();
+            let sigma = (target_width as f32 / BLUR_SIGMA_DIVISOR).max(1.0);
+            let mut canvas = imageops::fast_blur(&bg, sigma);
+            let fitted = base.resize(target_width, th, Lanczos3).to_rgba8();
+            let x = ((target_width.saturating_sub(fitted.width())) / 2) as i64;
+            let y = ((th.saturating_sub(fitted.height())) / 2) as i64;
+            imageops::overlay(&mut canvas, &fitted, x, y);
+            canvas
+        }
+    }
+}
+
 pub fn render_poster_sync(
     poster_bytes: &[u8],
     badges: &[RatingBadge],
@@ -277,21 +341,16 @@ pub fn render_poster_sync(
     badge_scale: f32,
     badge_size: BadgeSize,
     poster_badge_split: bool,
+    poster_fit: PosterFit,
 ) -> Result<Vec<u8>, AppError> {
     // A pill is a horizontal lozenge (icon/label left, value right) — never a
     // vertical stacked badge, even when the configured style is vertical.
     let badge_style = badge_style.for_shape(badge_appearance.shape);
     let base = load_image_with_limits(poster_bytes)?;
 
-    let base = if base.width() != target_width {
-        let scale = target_width as f64 / base.width() as f64;
-        let target_height = (base.height() as f64 * scale).round() as u32;
-        base.resize_exact(target_width, target_height, image::imageops::FilterType::Lanczos3)
-    } else {
-        base
-    };
-
-    let mut canvas: RgbaImage = base.to_rgba8();
+    // Normalize to the output frame (2:3 for every mode except Native) before
+    // overlaying badges, so badges anchor to the final frame corners.
+    let mut canvas: RgbaImage = fit_poster(base, target_width, poster_fit);
 
     if !badges.is_empty() {
         let badge_images: Vec<RgbaImage> = if badge_style.is_vertical() {
@@ -717,7 +776,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = render_poster_sync(&png_bytes, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert!(!result.is_empty());
         // Should be valid JPEG
         assert_eq!(result[0], 0xFF);
@@ -760,7 +819,7 @@ mod tests {
             },
         ];
 
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert!(!result.is_empty());
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
@@ -769,7 +828,7 @@ mod tests {
     #[test]
     fn render_poster_invalid_image_bytes() {
         let font = FontArc::try_from_slice(crate::FONT_BYTES).unwrap();
-        let result = render_poster_sync(b"not an image", &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false);
+        let result = render_poster_sync(b"not an image", &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native);
         assert!(result.is_err());
     }
 
@@ -1023,7 +1082,7 @@ mod tests {
                 value: "8.5".to_string(),
             },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::TopCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::TopCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1042,7 +1101,7 @@ mod tests {
                 value: "8.5".to_string(),
             },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::Left, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::Left, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1059,7 +1118,7 @@ mod tests {
                 value: "8.5".to_string(),
             },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::Right, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::Right, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1074,7 +1133,7 @@ mod tests {
             RatingBadge { source: RatingSource::Imdb, value: "8.5".to_string() },
             RatingBadge { source: RatingSource::Rt, value: "92%".to_string() },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Icon, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Icon, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1090,17 +1149,17 @@ mod tests {
             RatingBadge { source: RatingSource::Rt, value: "92%".to_string() },
         ];
         // vertical direction at bottom-center
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
 
         // vertical direction at top-left corner
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::TopLeft, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::TopLeft, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
 
         // vertical direction at bottom-right corner
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomRight, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomRight, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1147,7 +1206,7 @@ mod tests {
             RatingBadge { source: RatingSource::Rt, value: "92%".to_string() },
             RatingBadge { source: RatingSource::RtAudience, value: "45%".to_string() },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Official, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Official, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1210,6 +1269,7 @@ mod tests {
             badge_appearance: BadgeAppearance::default(),
             badge_direction: BadgeDirection::Horizontal,
             poster_badge_split: false,
+            poster_fit: PosterFit::Native,
             render_semaphore: sem.clone(),
             target_width: 500,
             badge_scale: 1.0,
@@ -1247,6 +1307,7 @@ mod tests {
             badge_appearance: BadgeAppearance::default(),
             badge_direction: BadgeDirection::Horizontal,
             poster_badge_split: false,
+            poster_fit: PosterFit::Native,
             render_semaphore: sem,
             target_width: 500,
             badge_scale: 1.0,
@@ -1338,7 +1399,7 @@ mod tests {
         let font = FontArc::try_from_slice(crate::FONT_BYTES).unwrap();
         let png = test_png(500, 750);
         // Render at large size (1280 width, ~2.2x badge scale)
-        let result = render_poster_sync(&png, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 1280, 2.2, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 1280, 2.2, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         assert!(!result.is_empty());
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
@@ -1356,7 +1417,7 @@ mod tests {
             RatingBadge { source: RatingSource::Imdb, value: "8.5".to_string() },
             RatingBadge { source: RatingSource::Rt, value: "92%".to_string() },
         ];
-        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 1280, 2.2, BadgeSize::Medium, false).unwrap();
+        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 1280, 2.2, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         let img = image::load_from_memory(&result).unwrap();
         assert_eq!(img.width(), 1280);
     }
@@ -1372,12 +1433,12 @@ mod tests {
             RatingBadge { source: RatingSource::Tmdb, value: "85%".to_string() },
         ];
         // Large badge size with horizontal style — should use max 2 per row
-        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Large, false).unwrap();
+        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Large, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
 
         // Extra-large badge size with vertical style — should use max 4 per row
-        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Vertical, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::ExtraLarge, false).unwrap();
+        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Vertical, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::ExtraLarge, false, PosterFit::Native).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1420,7 +1481,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::TopCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cy < 0.33, "TopCenter: badge y-centroid {cy:.2} should be in top third");
         assert!(cx > 0.3 && cx < 0.7, "TopCenter: badge x-centroid {cx:.2} should be centered");
@@ -1432,7 +1493,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cy > 0.67, "BottomCenter: badge y-centroid {cy:.2} should be in bottom third");
         assert!(cx > 0.3 && cx < 0.7, "BottomCenter: badge x-centroid {cx:.2} should be centered");
@@ -1444,7 +1505,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::Left, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cx < 0.5, "Left: badge x-centroid {cx:.2} should be in left half");
         assert!(cy > 0.25 && cy < 0.75, "Left: badge y-centroid {cy:.2} should be vertically centered");
@@ -1456,7 +1517,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::Right, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cx > 0.5, "Right: badge x-centroid {cx:.2} should be in right half");
         assert!(cy > 0.25 && cy < 0.75, "Right: badge y-centroid {cy:.2} should be vertically centered");
@@ -1468,7 +1529,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::TopLeft, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cx < 0.5, "TopLeft: badge x-centroid {cx:.2} should be in left half");
         assert!(cy < 0.5, "TopLeft: badge y-centroid {cy:.2} should be in top half");
@@ -1480,7 +1541,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::BottomRight, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cx > 0.5, "BottomRight: badge x-centroid {cx:.2} should be in right half");
         assert!(cy > 0.5, "BottomRight: badge y-centroid {cy:.2} should be in bottom half");
@@ -1521,7 +1582,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &split_test_badges(), &font, 85,
             BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, true).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, true, PosterFit::Native).unwrap();
         let (top, bottom, _l, _r) = badge_pixel_halves(&result);
         assert!(top > 0, "split: expected badge pixels in the top half, got {top}");
         assert!(bottom > 0, "split: expected badge pixels in the bottom half, got {bottom}");
@@ -1530,7 +1591,7 @@ mod tests {
         let unsplit = render_poster_sync(&test_png(500, 750), &split_test_badges(), &font, 85,
             BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
         let (top_u, _b, _l, _r) = badge_pixel_halves(&unsplit);
         assert_eq!(top_u, 0, "no-split: expected no badge pixels in the top half, got {top_u}");
     }
@@ -1542,7 +1603,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &split_test_badges(), &font, 85,
             BadgePosition::Left, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, true).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, true, PosterFit::Native).unwrap();
         let (_t, _b, left, right) = badge_pixel_halves(&result);
         assert!(left > 0, "split: expected badge pixels in the left half, got {left}");
         assert!(right > 0, "split: expected badge pixels in the right half, got {right}");
@@ -1559,10 +1620,63 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &badges, &font, 85,
             BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, true).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, true, PosterFit::Native).unwrap();
         let (top, bottom, _l, _r) = badge_pixel_halves(&result);
         assert_eq!(top, 0, "single badge: nothing should move to the top half, got {top}");
         assert!(bottom > 0, "single badge: badge should remain in the bottom half, got {bottom}");
+    }
+
+    /// Decode a rendered poster and return its (width, height).
+    fn rendered_dims(bytes: &[u8]) -> (u32, u32) {
+        let img = image::load_from_memory(bytes).unwrap();
+        (img.width(), img.height())
+    }
+
+    fn render_with_fit(src: &[u8], target_width: u32, fit: PosterFit) -> Vec<u8> {
+        let font = FontArc::try_from_slice(crate::FONT_BYTES).unwrap();
+        render_poster_sync(
+            src, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal,
+            LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal,
+            target_width, 1.0, BadgeSize::Medium, false, fit,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn poster_fit_cover_normalizes_non_2_3_to_2_3() {
+        // A square (1:1) source is the kind of art that downstream apps crop.
+        let out = render_with_fit(&test_png(600, 600), 580, PosterFit::Cover);
+        assert_eq!(rendered_dims(&out), (580, 870), "cover must produce an exact 2:3 frame");
+    }
+
+    #[test]
+    fn poster_fit_pad_normalizes_non_2_3_to_2_3() {
+        let out = render_with_fit(&test_png(900, 600), 580, PosterFit::Pad);
+        assert_eq!(rendered_dims(&out), (580, 870), "pad must produce an exact 2:3 frame");
+    }
+
+    #[test]
+    fn poster_fit_blur_normalizes_non_2_3_to_2_3() {
+        let out = render_with_fit(&test_png(600, 600), 580, PosterFit::Blur);
+        assert_eq!(rendered_dims(&out), (580, 870), "blur must produce an exact 2:3 frame");
+    }
+
+    #[test]
+    fn poster_fit_native_preserves_source_ratio() {
+        // Native keeps the legacy behavior: scale to width, keep the source ratio.
+        let square = render_with_fit(&test_png(600, 600), 580, PosterFit::Native);
+        assert_eq!(rendered_dims(&square), (580, 580), "native keeps a 1:1 source 1:1");
+        let wide = render_with_fit(&test_png(900, 600), 580, PosterFit::Native);
+        // round(600 * 580 / 900) = 387
+        assert_eq!(rendered_dims(&wide), (580, 387), "native keeps a 3:2 source ratio");
+    }
+
+    #[test]
+    fn poster_fit_already_2_3_unchanged_dims_across_modes() {
+        for fit in [PosterFit::Native, PosterFit::Cover, PosterFit::Pad, PosterFit::Blur] {
+            let out = render_with_fit(&test_png(500, 750), 580, fit);
+            assert_eq!(rendered_dims(&out), (580, 870), "2:3 source stays 2:3 for {fit:?}");
+        }
     }
 
     #[test]

--- a/api/src/image/serve.rs
+++ b/api/src/image/serve.rs
@@ -177,6 +177,7 @@ pub fn settings_cache_suffix_with_ratings(
         backdrop_label_style: _,
         poster_badge_direction: _,
         poster_badge_split: _,
+        poster_fit: _,
         poster_badge_size: _,
         logo_badge_size: _,
         backdrop_badge_size: _,
@@ -217,10 +218,14 @@ pub fn settings_cache_suffix_with_ratings(
             // Split badges onto opposite sides — only tokenized when enabled, so
             // the default (no split) keeps existing cache keys unchanged.
             let split = if settings.poster_badge_split { ".x1" } else { "" };
+            // Poster aspect-ratio fit. `Native` emits no token, so pre-feature
+            // poster cache keys (all native) stay valid for native requests; the
+            // default (Cover) emits a token, intentionally missing those entries.
+            let fit = settings.poster_fit.cache_suffix();
             // Shape/background sit immediately after badge size (before the
             // optional split token) so the v003 cache-key migration can insert
             // their defaults with a single uniform rule across all image types.
-            format!("{rs}{ps}{bs}{ls}{bd}{bsz}{shp}{bgd}{split}{is_suffix}")
+            format!("{rs}{ps}{bs}{ls}{bd}{bsz}{shp}{bgd}{split}{fit}{is_suffix}")
         }
         cache::ImageType::Logo => {
             let bs = badge_style_cache_suffix(settings.logo_badge_style.for_shape(settings.logo_badge_shape).as_str());
@@ -1360,6 +1365,7 @@ async fn generate_poster_with_source(
         badge_appearance: settings.poster_appearance(),
         badge_direction: settings.poster_badge_direction,
         poster_badge_split: settings.poster_badge_split,
+        poster_fit: settings.poster_fit,
         render_semaphore: state.render_semaphore.clone(),
         target_width,
         badge_scale,
@@ -1572,7 +1578,7 @@ async fn resolve_tmdb_poster_path(
     textless: bool,
 ) -> Option<String> {
     let tmdb_images = get_tmdb_images_cached(state, resolved, lang).await?;
-    let selected = crate::services::tmdb::TmdbClient::select_image(&tmdb_images.posters, lang, textless)?;
+    let selected = crate::services::tmdb::TmdbClient::select_poster(&tmdb_images.posters, lang, textless)?;
     Some(selected.file_path.clone())
 }
 
@@ -2166,6 +2172,37 @@ mod tests {
         assert_ne!(
             settings_hash(&s1, cache::ImageType::Poster, None),
             settings_hash(&s2, cache::ImageType::Poster, None)
+        );
+    }
+
+    #[test]
+    fn poster_fit_cache_suffix_tokens() {
+        use crate::services::db::PosterFit;
+        let mut s = RenderSettings::default();
+        s.poster_fit = PosterFit::Native;
+        let native = settings_cache_suffix(&s, cache::ImageType::Poster, None);
+        s.poster_fit = PosterFit::Cover;
+        let cover = settings_cache_suffix(&s, cache::ImageType::Poster, None);
+        s.poster_fit = PosterFit::Pad;
+        let pad = settings_cache_suffix(&s, cache::ImageType::Poster, None);
+        // Native emits no token so pre-feature (native) poster cache keys stay valid.
+        assert!(!native.contains(".f"), "native must not emit a fit token: {native}");
+        assert!(cover.contains(".fc"), "cover token missing: {cover}");
+        assert!(pad.contains(".fp"), "pad token missing: {pad}");
+        assert_ne!(native, cover);
+        assert_ne!(cover, pad);
+    }
+
+    #[test]
+    fn settings_hash_differs_by_poster_fit() {
+        use crate::services::db::PosterFit;
+        let mut a = RenderSettings::default();
+        a.poster_fit = PosterFit::Cover;
+        let mut b = RenderSettings::default();
+        b.poster_fit = PosterFit::Blur;
+        assert_ne!(
+            settings_hash(&a, cache::ImageType::Poster, None),
+            settings_hash(&b, cache::ImageType::Poster, None)
         );
     }
 

--- a/api/src/image/serve.rs
+++ b/api/src/image/serve.rs
@@ -218,9 +218,9 @@ pub fn settings_cache_suffix_with_ratings(
             // Split badges onto opposite sides — only tokenized when enabled, so
             // the default (no split) keeps existing cache keys unchanged.
             let split = if settings.poster_badge_split { ".x1" } else { "" };
-            // Poster aspect-ratio fit. `Native` emits no token, so pre-feature
-            // poster cache keys (all native) stay valid for native requests; the
-            // default (Cover) emits a token, intentionally missing those entries.
+            // Poster aspect-ratio fit. `Native` (the default) emits no token, so
+            // pre-feature poster cache keys — all native — stay valid and the
+            // default reuses them. Opting into cover/pad/blur emits a token.
             let fit = settings.poster_fit.cache_suffix();
             // Shape/background sit immediately after badge size (before the
             // optional split token) so the v003 cache-key migration can insert

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -382,4 +382,8 @@ pub const MIGRATIONS: &[(&str, &str)] = &[
         "ALTER TABLE api_key_settings ADD COLUMN poster_badge_split INTEGER NOT NULL DEFAULT 0",
         "duplicate column",
     ),
+    (
+        "ALTER TABLE api_key_settings ADD COLUMN poster_fit TEXT NOT NULL DEFAULT 'cover'",
+        "duplicate column",
+    ),
 ];

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -383,7 +383,7 @@ pub const MIGRATIONS: &[(&str, &str)] = &[
         "duplicate column",
     ),
     (
-        "ALTER TABLE api_key_settings ADD COLUMN poster_fit TEXT NOT NULL DEFAULT 'cover'",
+        "ALTER TABLE api_key_settings ADD COLUMN poster_fit TEXT NOT NULL DEFAULT 'native'",
         "duplicate column",
     ),
 ];

--- a/api/src/services/db.rs
+++ b/api/src/services/db.rs
@@ -770,11 +770,11 @@ impl PosterFit {
         }
     }
 
-    /// Cache key suffix. `Native` returns an empty string so that poster cache
-    /// keys written before this feature existed (all rendered natively) stay
-    /// valid for native requests and aren't needlessly invalidated. The new
-    /// default (`Cover`) emits a token, so default requests miss the old
-    /// native-keyed entries and re-render — which is the intended behavior.
+    /// Cache key suffix. `Native` (the default) returns an empty string so that
+    /// poster cache keys written before this feature existed — all rendered
+    /// natively — remain valid and the default behavior reuses them with no
+    /// re-render. Opting into `cover`/`pad`/`blur` emits a token, producing a
+    /// distinct cache entry.
     pub fn cache_suffix(self) -> &'static str {
         match self {
             Self::Native => "",
@@ -787,9 +787,10 @@ impl PosterFit {
 
 impl_str_enum!(PosterFit);
 
-/// Default poster fit: center-crop to the standard 2:3 frame.
+/// Default poster fit: `Native` (keep the source aspect ratio — legacy
+/// behavior). Normalization to 2:3 (`cover`/`pad`/`blur`) is opt-in.
 pub fn default_poster_fit() -> PosterFit {
-    PosterFit::Cover
+    PosterFit::Native
 }
 
 /// Validate ratings_limit is 0–10 (one slot per available rating source).
@@ -1577,7 +1578,7 @@ mod tests {
         assert_eq!(defaults.poster_badge_size, BadgeSize::Medium);
         assert_eq!(defaults.logo_badge_size, BadgeSize::Medium);
         assert_eq!(defaults.backdrop_badge_size, BadgeSize::Medium);
-        assert_eq!(defaults.poster_fit, PosterFit::Cover);
+        assert_eq!(defaults.poster_fit, PosterFit::Native);
         assert!(defaults.is_default);
     }
 
@@ -1587,7 +1588,7 @@ mod tests {
             assert_eq!(PosterFit::parse(f.as_str()).unwrap(), f);
         }
         assert!(PosterFit::parse("bogus").is_err());
-        assert_eq!(default_poster_fit(), PosterFit::Cover);
+        assert_eq!(default_poster_fit(), PosterFit::Native);
         // Native must keep an empty token so pre-feature poster cache keys survive.
         assert_eq!(PosterFit::Native.cache_suffix(), "");
         assert_eq!(PosterFit::Cover.cache_suffix(), ".fc");

--- a/api/src/services/db.rs
+++ b/api/src/services/db.rs
@@ -721,6 +721,77 @@ impl BadgeSize {
 
 impl_str_enum!(BadgeSize);
 
+// --- Poster aspect-ratio fit ---
+
+const FIT_NATIVE: &str = "native";
+const FIT_COVER: &str = "cover";
+const FIT_PAD: &str = "pad";
+const FIT_BLUR: &str = "blur";
+
+/// How a poster is fit to the standard 2:3 output frame.
+///
+/// Downstream apps (Stremio addons, aiometadata) place posters in fixed 2:3
+/// containers, so a non-2:3 source poster gets cropped by the client — cutting
+/// off the title/logo baked into the art (issue #15). Every mode except
+/// `Native` normalizes the output to an exact 2:3 frame so nothing is clipped
+/// by the consumer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PosterFit {
+    /// Keep the source aspect ratio (legacy behavior, no normalization).
+    Native,
+    /// Scale to fill the 2:3 frame, center-cropping the overflow.
+    Cover,
+    /// Fit the whole poster inside the 2:3 frame, padding with solid black bars.
+    Pad,
+    /// Fit the whole poster inside the 2:3 frame, filling the bars with a
+    /// blurred, zoomed copy of the poster.
+    Blur,
+}
+
+impl PosterFit {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Native => FIT_NATIVE,
+            Self::Cover => FIT_COVER,
+            Self::Pad => FIT_PAD,
+            Self::Blur => FIT_BLUR,
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self, AppError> {
+        match s {
+            FIT_NATIVE => Ok(Self::Native),
+            FIT_COVER => Ok(Self::Cover),
+            FIT_PAD => Ok(Self::Pad),
+            FIT_BLUR => Ok(Self::Blur),
+            _ => Err(AppError::BadRequest(format!(
+                "poster_fit must be '{FIT_NATIVE}', '{FIT_COVER}', '{FIT_PAD}', or '{FIT_BLUR}'"
+            ))),
+        }
+    }
+
+    /// Cache key suffix. `Native` returns an empty string so that poster cache
+    /// keys written before this feature existed (all rendered natively) stay
+    /// valid for native requests and aren't needlessly invalidated. The new
+    /// default (`Cover`) emits a token, so default requests miss the old
+    /// native-keyed entries and re-render — which is the intended behavior.
+    pub fn cache_suffix(self) -> &'static str {
+        match self {
+            Self::Native => "",
+            Self::Cover => ".fc",
+            Self::Pad => ".fp",
+            Self::Blur => ".fb",
+        }
+    }
+}
+
+impl_str_enum!(PosterFit);
+
+/// Default poster fit: center-crop to the standard 2:3 frame.
+pub fn default_poster_fit() -> PosterFit {
+    PosterFit::Cover
+}
+
 /// Validate ratings_limit is 0–10 (one slot per available rating source).
 pub fn validate_ratings_limit(limit: i32) -> Result<(), AppError> {
     if (0..=10).contains(&limit) {
@@ -1506,7 +1577,30 @@ mod tests {
         assert_eq!(defaults.poster_badge_size, BadgeSize::Medium);
         assert_eq!(defaults.logo_badge_size, BadgeSize::Medium);
         assert_eq!(defaults.backdrop_badge_size, BadgeSize::Medium);
+        assert_eq!(defaults.poster_fit, PosterFit::Cover);
         assert!(defaults.is_default);
+    }
+
+    #[test]
+    fn poster_fit_parse_round_trip_and_tokens() {
+        for f in [PosterFit::Native, PosterFit::Cover, PosterFit::Pad, PosterFit::Blur] {
+            assert_eq!(PosterFit::parse(f.as_str()).unwrap(), f);
+        }
+        assert!(PosterFit::parse("bogus").is_err());
+        assert_eq!(default_poster_fit(), PosterFit::Cover);
+        // Native must keep an empty token so pre-feature poster cache keys survive.
+        assert_eq!(PosterFit::Native.cache_suffix(), "");
+        assert_eq!(PosterFit::Cover.cache_suffix(), ".fc");
+        assert_eq!(PosterFit::Pad.cache_suffix(), ".fp");
+        assert_eq!(PosterFit::Blur.cache_suffix(), ".fb");
+    }
+
+    #[test]
+    fn parse_global_render_settings_reads_poster_fit() {
+        let mut globals = HashMap::new();
+        globals.insert("poster_fit".into(), "pad".into());
+        let settings = parse_global_render_settings(&globals);
+        assert_eq!(settings.poster_fit, PosterFit::Pad);
     }
 }
 
@@ -1886,6 +1980,7 @@ pub struct UpsertApiKeySettings<'a> {
     pub backdrop_label_style: &'a str,
     pub poster_badge_direction: &'a str,
     pub poster_badge_split: bool,
+    pub poster_fit: &'a str,
     pub poster_badge_size: &'a str,
     pub logo_badge_size: &'a str,
     pub backdrop_badge_size: &'a str,
@@ -1931,6 +2026,7 @@ pub async fn upsert_api_key_settings(
         backdrop_label_style: Set(params.backdrop_label_style.to_string()),
         poster_badge_direction: Set(params.poster_badge_direction.to_string()),
         poster_badge_split: Set(params.poster_badge_split),
+        poster_fit: Set(params.poster_fit.to_string()),
         poster_badge_size: Set(params.poster_badge_size.to_string()),
         logo_badge_size: Set(params.logo_badge_size.to_string()),
         backdrop_badge_size: Set(params.backdrop_badge_size.to_string()),
@@ -1973,6 +2069,7 @@ pub async fn upsert_api_key_settings(
                     api_key_settings::Column::BackdropLabelStyle,
                     api_key_settings::Column::PosterBadgeDirection,
                     api_key_settings::Column::PosterBadgeSplit,
+                    api_key_settings::Column::PosterFit,
                     api_key_settings::Column::PosterBadgeSize,
                     api_key_settings::Column::LogoBadgeSize,
                     api_key_settings::Column::BackdropBadgeSize,
@@ -2038,6 +2135,8 @@ pub struct RenderSettings {
     /// When true, poster badges are split evenly across two opposite sides
     /// (left/right for a vertical badge layout, top/bottom for horizontal rows).
     pub poster_badge_split: bool,
+    /// How non-2:3 posters are fit to the standard 2:3 output frame.
+    pub poster_fit: PosterFit,
     pub poster_badge_size: BadgeSize,
     pub logo_badge_size: BadgeSize,
     pub backdrop_badge_size: BadgeSize,
@@ -2100,6 +2199,7 @@ impl Default for RenderSettings {
             backdrop_label_style: LabelStyle::Official,
             poster_badge_direction: BadgeDirection::Default,
             poster_badge_split: false,
+            poster_fit: default_poster_fit(),
             poster_badge_size: BadgeSize::Medium,
             logo_badge_size: BadgeSize::Medium,
             backdrop_badge_size: BadgeSize::Medium,
@@ -2171,6 +2271,7 @@ pub fn parse_global_render_settings(globals: &HashMap<String, String>) -> Render
             .get("poster_badge_split")
             .map(|v| v == "true")
             .unwrap_or(defaults.poster_badge_split),
+        poster_fit: global_or(globals, "poster_fit", PosterFit::parse, defaults.poster_fit),
         poster_badge_size: global_or(globals, "poster_badge_size", BadgeSize::parse, defaults.poster_badge_size),
         logo_badge_size: global_or(globals, "logo_badge_size", BadgeSize::parse, defaults.logo_badge_size),
         backdrop_badge_size: global_or(globals, "backdrop_badge_size", BadgeSize::parse, defaults.backdrop_badge_size),
@@ -2227,6 +2328,7 @@ pub async fn get_effective_render_settings(
                 backdrop_label_style: parse_setting_or_default(&s.backdrop_label_style, "backdrop_label_style", LabelStyle::parse, LabelStyle::Official),
                 poster_badge_direction: parse_setting_or_default(&s.poster_badge_direction, "poster_badge_direction", BadgeDirection::parse, BadgeDirection::Default),
                 poster_badge_split: s.poster_badge_split,
+                poster_fit: parse_setting_or_default(&s.poster_fit, "poster_fit", PosterFit::parse, default_poster_fit()),
                 poster_badge_size: parse_setting_or_default(&s.poster_badge_size, "poster_badge_size", BadgeSize::parse, BadgeSize::Medium),
                 logo_badge_size: parse_setting_or_default(&s.logo_badge_size, "logo_badge_size", BadgeSize::parse, BadgeSize::Medium),
                 backdrop_badge_size: parse_setting_or_default(&s.backdrop_badge_size, "backdrop_badge_size", BadgeSize::parse, BadgeSize::Medium),

--- a/api/src/services/tmdb.rs
+++ b/api/src/services/tmdb.rs
@@ -7,6 +7,13 @@ use zeroize::Zeroizing;
 
 use super::lang::{lang_base, lang_region};
 
+/// Standard movie-poster aspect ratio (width:height = 2:3 ≈ 0.667).
+const POSTER_TARGET_RATIO: f64 = 2.0 / 3.0;
+/// Tolerance around [`POSTER_TARGET_RATIO`] for treating a poster as "standard".
+/// TMDB posters are 0.667 (2:3) or occasionally 0.675; this admits both while
+/// rejecting square (1.0) or otherwise off-ratio art.
+const POSTER_RATIO_TOL: f64 = 0.05;
+
 #[derive(Clone)]
 pub struct TmdbClient {
     api_key: Arc<Zeroizing<String>>,
@@ -92,11 +99,45 @@ impl TmdbClient {
     /// When `lang` is empty (e.g. backdrops): returns the best null-language
     /// image, since backdrops are inherently language-agnostic.
     pub fn select_image<'a>(images: &'a [TmdbImage], lang: &str, textless: bool) -> Option<&'a TmdbImage> {
+        Self::select_image_ranked(images, lang, textless, None)
+    }
+
+    /// Like [`select_image`], but for posters: among the candidates in each
+    /// language tier, prefer art close to the standard 2:3 aspect ratio before
+    /// falling back to highest vote. This keeps non-2:3 source posters (which
+    /// downstream apps crop, cutting off title art — issue #15) from being
+    /// chosen when a 2:3 poster is available. Falls back to vote-only ranking
+    /// when no candidate is near 2:3.
+    pub fn select_poster<'a>(images: &'a [TmdbImage], lang: &str, textless: bool) -> Option<&'a TmdbImage> {
+        Self::select_image_ranked(images, lang, textless, Some(POSTER_TARGET_RATIO))
+    }
+
+    fn select_image_ranked<'a>(
+        images: &'a [TmdbImage],
+        lang: &str,
+        textless: bool,
+        target_ratio: Option<f64>,
+    ) -> Option<&'a TmdbImage> {
+        // Rank candidates by (near-target aspect ratio, then vote_average).
+        // `max_by` picks a standard-ratio image over any off-ratio one, and the
+        // highest vote among equals. With `target_ratio = None` (logos,
+        // backdrops) the ratio key is always false, so ranking is vote-only —
+        // identical to the previous behavior.
+        let rank = |img: &TmdbImage| -> (bool, f64) {
+            let standard = match target_ratio {
+                Some(r) => img.aspect_ratio > 0.0 && (img.aspect_ratio - r).abs() <= POSTER_RATIO_TOL,
+                None => false,
+            };
+            (standard, img.vote_average)
+        };
+        let cmp = |a: &&TmdbImage, b: &&TmdbImage| {
+            rank(a).partial_cmp(&rank(b)).unwrap_or(std::cmp::Ordering::Equal)
+        };
         let find_best = |target: Option<&str>| -> Option<&TmdbImage> {
             images
                 .iter()
                 .filter(|img| img.iso_639_1.as_deref() == target)
-                .max_by(|a, b| a.vote_average.partial_cmp(&b.vote_average).unwrap_or(std::cmp::Ordering::Equal))
+                .max_by(cmp)
         };
 
         if textless {
@@ -115,7 +156,7 @@ impl TmdbClient {
             let regional = images
                 .iter()
                 .filter(|img| img.iso_639_1.as_deref() == Some(base) && img.iso_3166_1.as_deref() == Some(region))
-                .max_by(|a, b| a.vote_average.partial_cmp(&b.vote_average).unwrap_or(std::cmp::Ordering::Equal));
+                .max_by(cmp);
             if let Some(img) = regional {
                 return Some(img);
             }
@@ -151,6 +192,11 @@ pub struct TmdbImage {
     #[serde(default)]
     pub iso_3166_1: Option<String>,
     pub vote_average: f64,
+    /// Source aspect ratio (width/height) as reported by TMDB. Defaults to 0.0
+    /// when absent, which the poster selector treats as "unknown" (never
+    /// preferred as a standard-ratio candidate).
+    #[serde(default)]
+    pub aspect_ratio: f64,
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
@@ -168,11 +214,18 @@ mod tests {
     use super::*;
 
     fn img(path: &str, lang: Option<&str>, vote: f64) -> TmdbImage {
+        // Default to a standard 2:3 ratio; the language-selection tests use
+        // `select_image` (no ratio preference), so this value is irrelevant there.
+        img_ar(path, lang, vote, 2.0 / 3.0)
+    }
+
+    fn img_ar(path: &str, lang: Option<&str>, vote: f64, aspect_ratio: f64) -> TmdbImage {
         TmdbImage {
             file_path: path.to_string(),
             iso_639_1: lang.map(|s| s.to_string()),
             iso_3166_1: None,
             vote_average: vote,
+            aspect_ratio,
         }
     }
 
@@ -182,6 +235,7 @@ mod tests {
             iso_639_1: Some(lang.to_string()),
             iso_3166_1: Some(region.to_string()),
             vote_average: vote,
+            aspect_ratio: 2.0 / 3.0,
         }
     }
 
@@ -339,5 +393,48 @@ mod tests {
         ];
         let selected = TmdbClient::select_image(&images, "en-GB", false).unwrap();
         assert_eq!(selected.file_path, "/en_gb.jpg");
+    }
+
+    #[test]
+    fn select_poster_prefers_standard_ratio_over_higher_vote() {
+        // A square poster with a higher vote should lose to a true 2:3 poster.
+        let images = vec![
+            img_ar("/square.jpg", Some("en"), 9.0, 1.0),
+            img_ar("/poster.jpg", Some("en"), 6.0, 2.0 / 3.0),
+        ];
+        let selected = TmdbClient::select_poster(&images, "en", false).unwrap();
+        assert_eq!(selected.file_path, "/poster.jpg");
+    }
+
+    #[test]
+    fn select_poster_prefers_highest_vote_among_standard_ratio() {
+        let images = vec![
+            img_ar("/p_low.jpg", Some("en"), 5.0, 2.0 / 3.0),
+            img_ar("/p_high.jpg", Some("en"), 8.0, 0.675), // within tolerance of 2:3
+            img_ar("/square.jpg", Some("en"), 9.5, 1.0),
+        ];
+        let selected = TmdbClient::select_poster(&images, "en", false).unwrap();
+        assert_eq!(selected.file_path, "/p_high.jpg");
+    }
+
+    #[test]
+    fn select_poster_falls_back_to_vote_when_no_standard_ratio() {
+        let images = vec![
+            img_ar("/square_low.jpg", Some("en"), 3.0, 1.0),
+            img_ar("/square_high.jpg", Some("en"), 8.0, 1.0),
+        ];
+        let selected = TmdbClient::select_poster(&images, "en", false).unwrap();
+        assert_eq!(selected.file_path, "/square_high.jpg");
+    }
+
+    #[test]
+    fn select_image_ignores_aspect_ratio() {
+        // The generic selector (logos/backdrops) stays vote-only regardless of ratio.
+        let images = vec![
+            img_ar("/wide_high.jpg", Some("en"), 9.0, 1.78),
+            img_ar("/poster_low.jpg", Some("en"), 4.0, 2.0 / 3.0),
+        ];
+        let selected = TmdbClient::select_image(&images, "en", false).unwrap();
+        assert_eq!(selected.file_path, "/wide_high.jpg");
     }
 }

--- a/api/tests/db_operations.rs
+++ b/api/tests/db_operations.rs
@@ -23,6 +23,7 @@ fn test_upsert(key_id: i32) -> UpsertApiKeySettings<'static> {
         backdrop_label_style: "t",
         poster_badge_direction: "d",
         poster_badge_split: false,
+        poster_fit: "cover",
         poster_badge_size: "m",
         logo_badge_size: "m",
         backdrop_badge_size: "m",

--- a/web/src/__tests__/components/FreeApiKeyCard.display.spec.ts
+++ b/web/src/__tests__/components/FreeApiKeyCard.display.spec.ts
@@ -27,7 +27,7 @@ function makeDefaults(overrides: Partial<FreeKeyDefaults> = {}): FreeKeyDefaults
     backdrop_position: 'tc', backdrop_badge_direction: 'd',
     episode_ratings_limit: 3, episode_badge_style: 'v', episode_label_style: 'o',
     episode_badge_size: 'm', episode_position: 'bc', episode_badge_direction: 'd',
-    episode_blur: false, ...overrides,
+    episode_blur: false, poster_fit: 'native', ...overrides,
   }
 }
 
@@ -99,6 +99,12 @@ describe('FreeApiKeyCard trigger display across image-type switches', () => {
 
     await setSelect(wrapper, 'free-image-type', 'backdrop')
     expect(triggerText(wrapper, 'free-badge-style')).toBe('Badge style: default (Horizontal)')
+  })
+
+  it('reflects the poster fit default annotation', async () => {
+    const wrapper = mountReal(makeDefaults({ poster_fit: 'cover' }))
+    await flushPromises()
+    expect(triggerText(wrapper, 'free-fit')).toBe('Fit: default (Crop to 2:3)')
   })
 
   it('reflects the server default annotation once defaults load after mount', async () => {

--- a/web/src/__tests__/components/FreeApiKeyCard.spec.ts
+++ b/web/src/__tests__/components/FreeApiKeyCard.spec.ts
@@ -32,6 +32,7 @@ function makeDefaults(overrides: Partial<FreeKeyDefaults> = {}): FreeKeyDefaults
     backdrop_label_style: 'o',
     poster_badge_direction: 'd',
     poster_badge_split: false,
+    poster_fit: 'native',
     poster_badge_size: 'm',
     logo_badge_size: 'm',
     backdrop_badge_size: 'm',
@@ -425,6 +426,22 @@ describe('FreeApiKeyCard', () => {
     await setSelectById(wrapper, 'free-image-type', 'episode')
 
     expect(wrapper.find('#free-textless').exists()).toBe(false)
+  })
+
+  it('adds the poster fit override to the query and clears it for non-poster types', async () => {
+    const wrapper = mountCard(true)
+    await setSelectById(wrapper, 'free-fit', 'cover')
+    expect(findCurlCode(wrapper).text()).toContain('fit=cover')
+
+    await setSelectById(wrapper, 'free-image-type', 'logo')
+    expect(findCurlCode(wrapper).text()).not.toContain('fit=')
+  })
+
+  it('episode does not show fit control', async () => {
+    const wrapper = mountCard(true)
+    await setSelectById(wrapper, 'free-image-type', 'episode')
+
+    expect(wrapper.find('#free-fit').exists()).toBe(false)
   })
 
   // --- Reflecting the server's global defaults ---

--- a/web/src/__tests__/components/RenderSettingsForm.spec.ts
+++ b/web/src/__tests__/components/RenderSettingsForm.spec.ts
@@ -26,7 +26,7 @@ const defaultSettings: RenderSettings = {
   backdrop_label_style: 'i',
   poster_badge_direction: 'd',
   poster_badge_split: false,
-  poster_fit: 'cover',
+  poster_fit: 'native',
   poster_badge_size: 'm',
   logo_badge_size: 'm',
   backdrop_badge_size: 'm',
@@ -93,7 +93,7 @@ describe('RenderSettingsForm', () => {
     mountForm({}, fetchPreview)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(3, 'mal,imdb,lb,rt,rta,mc,tmdb,trakt,mdblist,ebert', 'bc', 'h', 'i', 'd', 'm', '', false, 'r', 'd', 'cover')
+    expect(fetchPreview).toHaveBeenCalledWith(3, 'mal,imdb,lb,rt,rta,mc,tmdb,trakt,mdblist,ebert', 'bc', 'h', 'i', 'd', 'm', '', false, 'r', 'd', 'native')
   })
 
   it('calls fetchPreview with correct params for custom settings', async () => {
@@ -101,7 +101,7 @@ describe('RenderSettingsForm', () => {
     mountForm({ ratings_limit: 5, ratings_order: 'imdb,rt,tmdb' }, fetchPreview)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(5, expect.stringContaining('imdb'), expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), '', false, 'r', 'd', 'cover')
+    expect(fetchPreview).toHaveBeenCalledWith(5, expect.stringContaining('imdb'), expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), '', false, 'r', 'd', 'native')
   })
 
   it('sets preview src from blob after fetch', async () => {
@@ -128,7 +128,7 @@ describe('RenderSettingsForm', () => {
     vi.advanceTimersByTime(500)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(5, expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), '', false, 'r', 'd', 'cover')
+    expect(fetchPreview).toHaveBeenCalledWith(5, expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), '', false, 'r', 'd', 'native')
   })
 
   it('shows loading state while preview loads', async () => {
@@ -185,7 +185,7 @@ describe('RenderSettingsForm', () => {
     mountForm({ poster_position: 'l' }, fetchPreview)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(3, expect.any(String), 'l', 'h', 'i', 'd', 'm', '', false, 'r', 'd', 'cover')
+    expect(fetchPreview).toHaveBeenCalledWith(3, expect.any(String), 'l', 'h', 'i', 'd', 'm', '', false, 'r', 'd', 'native')
   })
 
   it('hides fanart checkbox when fanart_available is false', () => {
@@ -285,7 +285,7 @@ describe('RenderSettingsForm', () => {
     mountForm({ poster_badge_direction: 'v' }, fetchPreview)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(3, expect.any(String), 'bc', 'h', 'i', 'v', 'm', '', false, 'r', 'd', 'cover')
+    expect(fetchPreview).toHaveBeenCalledWith(3, expect.any(String), 'bc', 'h', 'i', 'v', 'm', '', false, 'r', 'd', 'native')
   })
 
   // --- Episode preview ---

--- a/web/src/__tests__/components/RenderSettingsForm.spec.ts
+++ b/web/src/__tests__/components/RenderSettingsForm.spec.ts
@@ -26,6 +26,7 @@ const defaultSettings: RenderSettings = {
   backdrop_label_style: 'i',
   poster_badge_direction: 'd',
   poster_badge_split: false,
+  poster_fit: 'cover',
   poster_badge_size: 'm',
   logo_badge_size: 'm',
   backdrop_badge_size: 'm',
@@ -92,7 +93,7 @@ describe('RenderSettingsForm', () => {
     mountForm({}, fetchPreview)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(3, 'mal,imdb,lb,rt,rta,mc,tmdb,trakt,mdblist,ebert', 'bc', 'h', 'i', 'd', 'm', '', false, 'r', 'd')
+    expect(fetchPreview).toHaveBeenCalledWith(3, 'mal,imdb,lb,rt,rta,mc,tmdb,trakt,mdblist,ebert', 'bc', 'h', 'i', 'd', 'm', '', false, 'r', 'd', 'cover')
   })
 
   it('calls fetchPreview with correct params for custom settings', async () => {
@@ -100,7 +101,7 @@ describe('RenderSettingsForm', () => {
     mountForm({ ratings_limit: 5, ratings_order: 'imdb,rt,tmdb' }, fetchPreview)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(5, expect.stringContaining('imdb'), expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), '', false, 'r', 'd')
+    expect(fetchPreview).toHaveBeenCalledWith(5, expect.stringContaining('imdb'), expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), '', false, 'r', 'd', 'cover')
   })
 
   it('sets preview src from blob after fetch', async () => {
@@ -127,7 +128,7 @@ describe('RenderSettingsForm', () => {
     vi.advanceTimersByTime(500)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(5, expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), '', false, 'r', 'd')
+    expect(fetchPreview).toHaveBeenCalledWith(5, expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), expect.any(String), '', false, 'r', 'd', 'cover')
   })
 
   it('shows loading state while preview loads', async () => {
@@ -184,7 +185,7 @@ describe('RenderSettingsForm', () => {
     mountForm({ poster_position: 'l' }, fetchPreview)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(3, expect.any(String), 'l', 'h', 'i', 'd', 'm', '', false, 'r', 'd')
+    expect(fetchPreview).toHaveBeenCalledWith(3, expect.any(String), 'l', 'h', 'i', 'd', 'm', '', false, 'r', 'd', 'cover')
   })
 
   it('hides fanart checkbox when fanart_available is false', () => {
@@ -284,7 +285,7 @@ describe('RenderSettingsForm', () => {
     mountForm({ poster_badge_direction: 'v' }, fetchPreview)
     await flushPromises()
 
-    expect(fetchPreview).toHaveBeenCalledWith(3, expect.any(String), 'bc', 'h', 'i', 'v', 'm', '', false, 'r', 'd')
+    expect(fetchPreview).toHaveBeenCalledWith(3, expect.any(String), 'bc', 'h', 'i', 'v', 'm', '', false, 'r', 'd', 'cover')
   })
 
   // --- Episode preview ---

--- a/web/src/components/FreeApiKeyCard.vue
+++ b/web/src/components/FreeApiKeyCard.vue
@@ -16,6 +16,7 @@ import {
   BADGE_BACKGROUND_LABELS,
   IMAGE_SOURCE_LABELS,
   POSITION_LABELS,
+  POSTER_FIT_LABELS,
 } from '@/lib/constants'
 import RatingsOrderList from '@/components/RatingsOrderList.vue'
 import { Button } from '@/components/ui/button'
@@ -62,6 +63,7 @@ const imagePosition = ref('default')
 const imageSource = ref('default')
 const textless = ref('default')
 const posterSplit = ref('default')
+const posterFit = ref('default')
 const ratingsOrderList = ref<string[]>(parseRatingsOrder(DEFAULT_RATINGS_ORDER))
 // Baseline the user's order is compared against to decide whether to send a
 // `ratings_order` override — the server's order once loaded, else the frontend default.
@@ -175,6 +177,7 @@ const textlessDefaultLabel = computed(() =>
 const splitDefaultLabel = computed(() =>
   defaults.value ? `Split badges: default (${defaults.value.poster_badge_split ? 'Yes' : 'No'})` : 'Split badges: default',
 )
+const fitDefaultLabel = computed(() => annotate('Fit', defaults.value?.poster_fit, POSTER_FIT_LABELS))
 const blurDefaultLabel = computed(() =>
   defaults.value ? `Blur: default (${defaults.value.episode_blur ? 'Yes' : 'No'})` : 'Blur: default',
 )
@@ -200,6 +203,7 @@ watch(imageType, (newType) => {
   // free of params the new type would ignore.
   textless.value = 'default'
   posterSplit.value = 'default'
+  posterFit.value = 'default'
   blur.value = 'default'
   // image_source is a single global default shared by every type, so it persists
   // across switches — except episode, which doesn't accept the param.
@@ -240,6 +244,7 @@ const queryString = computed(() => {
   if (imageType.value !== 'episode' && imageSource.value !== 'default') params.set('image_source', imageSource.value)
   if (imageType.value === 'poster' && textless.value !== 'default') params.set('textless', textless.value)
   if (imageType.value === 'poster' && posterSplit.value !== 'default') params.set('split', posterSplit.value)
+  if (imageType.value === 'poster' && posterFit.value !== 'default') params.set('fit', posterFit.value)
   if (imageType.value === 'episode' && blur.value !== 'default') params.set('blur', blur.value)
   const qs = params.toString()
   return qs ? `?${qs}` : ''
@@ -428,6 +433,18 @@ async function handleFetch() {
                 <SelectItem value="default" :key="splitDefaultLabel">{{ splitDefaultLabel }}</SelectItem>
                 <SelectItem value="true">Yes</SelectItem>
                 <SelectItem value="false">No</SelectItem>
+              </SelectContent>
+            </Select>
+            <Select v-model="posterFit">
+              <SelectTrigger id="free-fit" aria-label="Aspect ratio fit" class="bg-background">
+                <SelectValue placeholder="Fit: default" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default" :key="fitDefaultLabel">{{ fitDefaultLabel }}</SelectItem>
+                <SelectItem value="native">Native (source ratio)</SelectItem>
+                <SelectItem value="cover">Crop to 2:3</SelectItem>
+                <SelectItem value="blur">Blur fill to 2:3</SelectItem>
+                <SelectItem value="pad">Letterbox to 2:3</SelectItem>
               </SelectContent>
             </Select>
           </template>

--- a/web/src/components/RenderSettingsForm.vue
+++ b/web/src/components/RenderSettingsForm.vue
@@ -91,7 +91,7 @@ const editLogoLabelStyle = ref(props.settings.logo_label_style || 'o')
 const editBackdropLabelStyle = ref(props.settings.backdrop_label_style || 'o')
 const editPosterBadgeDirection = ref(props.settings.poster_badge_direction || 'd')
 const editPosterBadgeSplit = ref(props.settings.poster_badge_split ?? false)
-const editPosterFit = ref(props.settings.poster_fit || 'cover')
+const editPosterFit = ref(props.settings.poster_fit || 'native')
 const editPosterBadgeSize = ref(props.settings.poster_badge_size || 'm')
 const editLogoBadgeSize = ref(props.settings.logo_badge_size || 'm')
 const editBackdropBadgeSize = ref(props.settings.backdrop_badge_size || 'm')
@@ -131,7 +131,7 @@ function applySettings(s: RenderSettings) {
   editBackdropLabelStyle.value = s.backdrop_label_style || 'o'
   editPosterBadgeDirection.value = s.poster_badge_direction || 'd'
   editPosterBadgeSplit.value = s.poster_badge_split ?? false
-  editPosterFit.value = s.poster_fit || 'cover'
+  editPosterFit.value = s.poster_fit || 'native'
   editPosterBadgeSize.value = s.poster_badge_size || 'm'
   editLogoBadgeSize.value = s.logo_badge_size || 'm'
   editBackdropBadgeSize.value = s.backdrop_badge_size || 'm'
@@ -670,10 +670,10 @@ function toggleExclude(key: string, checked: boolean) {
                 <SelectValue placeholder="Select fit" />
               </SelectTrigger>
               <SelectContent>
+                <SelectItem value="native">Native (source ratio)</SelectItem>
                 <SelectItem value="cover">Crop to 2:3</SelectItem>
                 <SelectItem value="blur">Blur fill to 2:3</SelectItem>
                 <SelectItem value="pad">Letterbox to 2:3</SelectItem>
-                <SelectItem value="native">Native (source ratio)</SelectItem>
               </SelectContent>
             </Select>
             <p class="text-xs text-muted-foreground">

--- a/web/src/components/RenderSettingsForm.vue
+++ b/web/src/components/RenderSettingsForm.vue
@@ -36,6 +36,7 @@ export interface RenderSettings {
   backdrop_label_style: string
   poster_badge_direction: string
   poster_badge_split: boolean
+  poster_fit: string
   poster_badge_size: string
   logo_badge_size: string
   backdrop_badge_size: string
@@ -64,7 +65,7 @@ const props = defineProps<{
   loadSettings: () => Promise<RenderSettings | null>
   saveSettings: (s: SaveSettingsPayload) => Promise<string | null>
   resetSettings?: () => Promise<boolean>
-  fetchPreview: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string) => Promise<Response>
+  fetchPreview: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string, posterFit?: string) => Promise<Response>
   fetchLogoPreview?: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string) => Promise<Response>
   fetchBackdropPreview?: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, position?: string, badgeDirection?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string) => Promise<Response>
   fetchEpisodePreview?: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, position?: string, badgeDirection?: string, blur?: boolean, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string) => Promise<Response>
@@ -90,6 +91,7 @@ const editLogoLabelStyle = ref(props.settings.logo_label_style || 'o')
 const editBackdropLabelStyle = ref(props.settings.backdrop_label_style || 'o')
 const editPosterBadgeDirection = ref(props.settings.poster_badge_direction || 'd')
 const editPosterBadgeSplit = ref(props.settings.poster_badge_split ?? false)
+const editPosterFit = ref(props.settings.poster_fit || 'cover')
 const editPosterBadgeSize = ref(props.settings.poster_badge_size || 'm')
 const editLogoBadgeSize = ref(props.settings.logo_badge_size || 'm')
 const editBackdropBadgeSize = ref(props.settings.backdrop_badge_size || 'm')
@@ -129,6 +131,7 @@ function applySettings(s: RenderSettings) {
   editBackdropLabelStyle.value = s.backdrop_label_style || 'o'
   editPosterBadgeDirection.value = s.poster_badge_direction || 'd'
   editPosterBadgeSplit.value = s.poster_badge_split ?? false
+  editPosterFit.value = s.poster_fit || 'cover'
   editPosterBadgeSize.value = s.poster_badge_size || 'm'
   editLogoBadgeSize.value = s.logo_badge_size || 'm'
   editBackdropBadgeSize.value = s.backdrop_badge_size || 'm'
@@ -202,6 +205,7 @@ async function autoSave() {
       backdrop_label_style: editBackdropLabelStyle.value,
       poster_badge_direction: editPosterBadgeDirection.value,
       poster_badge_split: editPosterBadgeSplit.value,
+      poster_fit: editPosterFit.value,
       poster_badge_size: editPosterBadgeSize.value,
       logo_badge_size: editLogoBadgeSize.value,
       backdrop_badge_size: editBackdropBadgeSize.value,
@@ -248,7 +252,7 @@ async function autoSave() {
 
 // Auto-save on any setting change
 watch(
-  [editSource, editLang, editTextless, editRatingsLimit, editRatingsOrder, editRatingsExclude, editPosterPosition, editLogoRatingsLimit, editBackdropRatingsLimit, editPosterBadgeStyle, editLogoBadgeStyle, editBackdropBadgeStyle, editPosterLabelStyle, editLogoLabelStyle, editBackdropLabelStyle, editPosterBadgeDirection, editPosterBadgeSplit, editPosterBadgeSize, editLogoBadgeSize, editBackdropBadgeSize, editBackdropPosition, editBackdropBadgeDirection, editEpisodeRatingsLimit, editEpisodeBadgeStyle, editEpisodeLabelStyle, editEpisodeBadgeSize, editEpisodePosition, editEpisodeBadgeDirection, editEpisodeBlur, editPosterBadgeShape, editLogoBadgeShape, editBackdropBadgeShape, editEpisodeBadgeShape, editPosterBadgeBackground, editLogoBadgeBackground, editBackdropBadgeBackground, editEpisodeBadgeBackground],
+  [editSource, editLang, editTextless, editRatingsLimit, editRatingsOrder, editRatingsExclude, editPosterPosition, editLogoRatingsLimit, editBackdropRatingsLimit, editPosterBadgeStyle, editLogoBadgeStyle, editBackdropBadgeStyle, editPosterLabelStyle, editLogoLabelStyle, editBackdropLabelStyle, editPosterBadgeDirection, editPosterBadgeSplit, editPosterFit, editPosterBadgeSize, editLogoBadgeSize, editBackdropBadgeSize, editBackdropPosition, editBackdropBadgeDirection, editEpisodeRatingsLimit, editEpisodeBadgeStyle, editEpisodeLabelStyle, editEpisodeBadgeSize, editEpisodePosition, editEpisodeBadgeDirection, editEpisodeBlur, editPosterBadgeShape, editLogoBadgeShape, editBackdropBadgeShape, editEpisodeBadgeShape, editPosterBadgeBackground, editLogoBadgeBackground, editBackdropBadgeBackground, editEpisodeBadgeBackground],
   () => {
     if (syncing) return
     autoSave()
@@ -339,7 +343,7 @@ let backdropPreviewTimer: ReturnType<typeof setTimeout> | null = null
 let episodePreviewTimer: ReturnType<typeof setTimeout> | null = null
 
 function updatePosterPreview() {
-  fetchPreviewImage(posterPreview.value, (_limit, order) => props.fetchPreview(editRatingsLimit.value, order, editPosterPosition.value, editPosterBadgeStyle.value, editPosterLabelStyle.value, editPosterBadgeDirection.value, editPosterBadgeSize.value, editRatingsExclude.value.join(','), editPosterBadgeSplit.value, editPosterBadgeShape.value, editPosterBadgeBackground.value))
+  fetchPreviewImage(posterPreview.value, (_limit, order) => props.fetchPreview(editRatingsLimit.value, order, editPosterPosition.value, editPosterBadgeStyle.value, editPosterLabelStyle.value, editPosterBadgeDirection.value, editPosterBadgeSize.value, editRatingsExclude.value.join(','), editPosterBadgeSplit.value, editPosterBadgeShape.value, editPosterBadgeBackground.value, editPosterFit.value))
 }
 
 function updateLogoPreview() {
@@ -381,7 +385,7 @@ watch([editRatingsOrder, editRatingsExclude], () => {
 }, { deep: true })
 
 // Poster-only settings
-watch([editRatingsLimit, editPosterPosition, editPosterBadgeStyle, editPosterLabelStyle, editPosterBadgeDirection, editPosterBadgeSplit, editPosterBadgeSize, editPosterBadgeShape, editPosterBadgeBackground], () => {
+watch([editRatingsLimit, editPosterPosition, editPosterBadgeStyle, editPosterLabelStyle, editPosterBadgeDirection, editPosterBadgeSplit, editPosterFit, editPosterBadgeSize, editPosterBadgeShape, editPosterBadgeBackground], () => {
   if (syncing) return
   if (posterPreviewTimer) clearTimeout(posterPreviewTimer)
   posterPreviewTimer = setTimeout(updatePosterPreview, 500)
@@ -655,6 +659,26 @@ function toggleExclude(key: string, checked: boolean) {
                 <SelectItem value="n">None</SelectItem>
               </SelectContent>
             </Select>
+          </div>
+          <div class="space-y-2">
+            <Label :for="inputId('poster-fit')">Aspect ratio</Label>
+            <Select
+              :model-value="editPosterFit"
+              @update:model-value="editPosterFit = $event as string"
+            >
+              <SelectTrigger :id="inputId('poster-fit')" class="max-w-xs" data-testid="poster-fit-select">
+                <SelectValue placeholder="Select fit" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="cover">Crop to 2:3</SelectItem>
+                <SelectItem value="blur">Blur fill to 2:3</SelectItem>
+                <SelectItem value="pad">Letterbox to 2:3</SelectItem>
+                <SelectItem value="native">Native (source ratio)</SelectItem>
+              </SelectContent>
+            </Select>
+            <p class="text-xs text-muted-foreground">
+              How non-2:3 posters are fit to the standard 2:3 frame so clients don't crop them.
+            </p>
           </div>
           <div class="space-y-1">
             <div class="flex items-center gap-3">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -82,6 +82,7 @@ export interface SaveSettingsPayload {
   backdrop_label_style: string
   poster_badge_direction: string
   poster_badge_split: boolean
+  poster_fit: string
   poster_badge_size: string
   logo_badge_size: string
   backdrop_badge_size: string
@@ -146,8 +147,8 @@ export const adminApi = {
     get(`/api/admin/episodes/${key}/image`),
   fetchEpisode: (idType: string, idValue: string): Promise<Response> =>
     post(`/api/admin/episodes/${idType}/${idValue}/fetch`),
-  previewPoster: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string): Promise<Response> =>
-    get(buildUrl('/api/admin/preview/poster', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, position: posterPosition, badge_style: badgeStyle, label_style: labelStyle, badge_direction: badgeDirection, badge_size: badgeSize, split: posterSplit ? 'true' : undefined, badge_shape: badgeShape, badge_background: badgeBackground })),
+  previewPoster: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string, posterFit?: string): Promise<Response> =>
+    get(buildUrl('/api/admin/preview/poster', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, position: posterPosition, badge_style: badgeStyle, label_style: labelStyle, badge_direction: badgeDirection, badge_size: badgeSize, split: posterSplit ? 'true' : undefined, badge_shape: badgeShape, badge_background: badgeBackground, fit: posterFit })),
   previewLogo: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string): Promise<Response> =>
     get(buildUrl('/api/admin/preview/logo', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, badge_style: badgeStyle, label_style: labelStyle, badge_size: badgeSize, badge_shape: badgeShape, badge_background: badgeBackground })),
   previewBackdrop: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, position?: string, badgeDirection?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string): Promise<Response> =>
@@ -185,8 +186,8 @@ export const selfApi = {
     }),
   resetSettings: (): Promise<Response> =>
     keyRequest('/api/key/me/settings', { method: 'DELETE' }),
-  previewPoster: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string): Promise<Response> =>
-    keyRequest(buildUrl('/api/key/me/preview/poster', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, position: posterPosition, badge_style: badgeStyle, label_style: labelStyle, badge_direction: badgeDirection, badge_size: badgeSize, split: posterSplit ? 'true' : undefined, badge_shape: badgeShape, badge_background: badgeBackground })),
+  previewPoster: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string, posterFit?: string): Promise<Response> =>
+    keyRequest(buildUrl('/api/key/me/preview/poster', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, position: posterPosition, badge_style: badgeStyle, label_style: labelStyle, badge_direction: badgeDirection, badge_size: badgeSize, split: posterSplit ? 'true' : undefined, badge_shape: badgeShape, badge_background: badgeBackground, fit: posterFit })),
   previewLogo: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string): Promise<Response> =>
     keyRequest(buildUrl('/api/key/me/preview/logo', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, badge_style: badgeStyle, label_style: labelStyle, badge_size: badgeSize, badge_shape: badgeShape, badge_background: badgeBackground })),
   previewBackdrop: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, position?: string, badgeDirection?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string): Promise<Response> =>

--- a/web/src/lib/auth-api.ts
+++ b/web/src/lib/auth-api.ts
@@ -23,6 +23,7 @@ export interface FreeKeyDefaults {
   backdrop_label_style: string
   poster_badge_direction: string
   poster_badge_split: boolean
+  poster_fit: string
   poster_badge_size: string
   logo_badge_size: string
   backdrop_badge_size: string

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -74,6 +74,7 @@ export const BADGE_SIZE_LABELS: Record<string, string> = { xs: 'Extra Small', s:
 export const BADGE_SHAPE_LABELS: Record<string, string> = { r: 'Rounded', p: 'Pill' }
 export const BADGE_BACKGROUND_LABELS: Record<string, string> = { d: 'Default', k: 'Dark', t: 'Transparent', n: 'None' }
 export const IMAGE_SOURCE_LABELS: Record<string, string> = { t: 'TMDB', f: 'Fanart.tv' }
+export const POSTER_FIT_LABELS: Record<string, string> = { native: 'Native', cover: 'Crop to 2:3', blur: 'Blur fill', pad: 'Letterbox' }
 export const POSITION_LABELS: Record<string, string> = {
   bc: 'Bottom Center', tc: 'Top Center', l: 'Left', r: 'Right',
   tl: 'Top Left', tr: 'Top Right', bl: 'Bottom Left', br: 'Bottom Right',

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -67,6 +67,7 @@ async function toggleFreeApiKey() {
     backdrop_label_style: s.backdrop_label_style,
     poster_badge_direction: s.poster_badge_direction,
     poster_badge_split: s.poster_badge_split,
+    poster_fit: s.poster_fit,
     poster_badge_size: s.poster_badge_size,
     logo_badge_size: s.logo_badge_size,
     backdrop_badge_size: s.backdrop_badge_size,


### PR DESCRIPTION
Closes #15.

## Problem
Posters were rendered at their **source** aspect ratio — `render_poster_sync` scaled to `target_width` and kept the source height. TMDB posters are usually 2:3, but some titles (and Fanart art) aren't. Downstream apps (Stremio addons via aiometadata) drop posters into a fixed **2:3** container, so any non-2:3 image gets cropped by the client — cutting off the title/logo baked into the poster.

## Fix
Two complementary levers:

1. **Render-side normalization** — a new poster-only `poster_fit` setting can force every poster to an exact 2:3 frame (`580×870` / `1280×1920` / `2000×3000`):
   - `native` *(default)* — keep the source aspect ratio (legacy behavior; no normalization)
   - `cover` — scale to fill 2:3, center-crop the overflow (no bars)
   - `pad` — fit the whole poster inside 2:3 with solid black bars
   - `blur` — fit inside 2:3, fill the bars with a blurred, zoomed copy of the poster
2. **Selection-side preference** — `TmdbClient::select_poster` now prefers posters near 2:3 (within tolerance) before falling back to highest `vote_average`, so the chosen source needs little/no cropping. **This applies by default** (it isn't gated by `poster_fit`); logo/backdrop selection is unchanged (vote-only).

The default is `native`, so out-of-the-box rendering matches the prior behavior and the 2:3 normalization modes are opt-in (per the maintainer's preference).

## Configurability
Exposed as a per-key + global setting and a `?fit={native|cover|pad|blur}` query-param override, threaded through `RenderSettings`, both settings request/response structs, the free-key settings response, the cache key + CDN hash, the `api_key_settings.poster_fit` column (idempotent `ADD COLUMN ... DEFAULT 'native'` migration), OpenAPI, and the admin UI (new "Aspect ratio" dropdown with live preview).

### Cache behavior (no cache migration needed)
`PosterFit::Native` emits an **empty** cache-key token, so poster cache keys written before this feature (all rendered natively) stay valid — and since `native` is the default, default requests reuse existing cache entries with **no re-render**. Opting into `cover`/`pad`/`blur` emits a distinct token (`.fc`/`.fp`/`.fb`), producing separate cache entries. No `v00x` upgrade required.

## Tests
- Render dimension invariants: `cover`/`pad`/`blur` produce exact 2:3; `native` preserves source ratio; a 2:3 source is unchanged across all modes.
- Selection: prefers a 2:3 poster over a higher-voted off-ratio one; picks highest vote among 2:3 candidates; falls back to vote-only when none are 2:3; generic `select_image` ignores ratio.
- `poster_fit` round-trip/tokens + `native` default, `parse_global_render_settings`, cache-suffix tokens + `settings_hash` differ-by-fit, query-override mapping.
- All gates green locally: `cargo test` (800), `vitest` (295), `vite build`, `cargo build --release --features test-support`.

## Notes
- README documents the `?fit=` param (default `native`); poster dimensions reflect the source-ratio default, with the exact 2:3 sizes noted for the normalization modes.
- The admin live preview uses a 2:3 sample poster, so the fit modes look identical in the preview (the setting still applies to real non-2:3 posters). A non-2:3 preview sample could be added later to make the effect visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)