### PR TITLE
fix: keep image and key text inside the admin preview dialog

### DIFF
--- a/web/src/components/ImageListView.vue
+++ b/web/src/components/ImageListView.vue
@@ -189,9 +189,9 @@ const previewSizeClass = computed(() => {
 })
 
 const skeletonClass = computed(() => {
-  if (props.kind === 'poster') return 'h-[400px] w-[270px] rounded-md'
-  if (props.kind === 'logo') return 'h-[200px] w-[400px] rounded-md'
-  return 'h-[270px] w-[480px] rounded-md'
+  if (props.kind === 'poster') return 'h-[400px] w-[270px] max-w-full rounded-md'
+  if (props.kind === 'logo') return 'h-[200px] w-[400px] max-w-full rounded-md'
+  return 'h-[270px] w-[480px] max-w-full rounded-md'
 })
 </script>
 
@@ -284,15 +284,15 @@ const skeletonClass = computed(() => {
     <Dialog :open="previewOpen" @update:open="(v: boolean) => { if (!v) closePreview() }">
       <DialogContent :class="previewSizeClass">
         <DialogHeader>
-          <DialogTitle class="font-mono text-sm">{{ previewKey }}</DialogTitle>
+          <DialogTitle class="min-w-0 break-all pr-8 font-mono text-sm">{{ previewKey }}</DialogTitle>
         </DialogHeader>
-        <div class="flex items-center justify-center min-h-[200px]">
+        <div class="flex items-center justify-center min-h-[200px] min-w-0">
           <Skeleton v-if="previewLoading" :class="skeletonClass" />
           <img
             v-else-if="previewUrl"
             :src="previewUrl"
             :alt="previewKey"
-            class="max-h-[70vh] rounded-md object-contain"
+            class="max-h-[70vh] max-w-full rounded-md object-contain"
           />
           <p v-else class="text-sm text-muted-foreground">Failed to load {{ kindLabel }}</p>
         </div>


### PR DESCRIPTION
Fixes #58 — *Information and images overflow out of the image preview in the admin console.*

## Problem
The admin console's image-preview `Dialog` (in `ImageListView.vue`) only constrained the image's **height** (`max-h-[70vh]`). Because the `<img>` had no width constraint and sat inside a CSS grid/flex layout (whose items default to `min-width: auto`):

- **Images overflowed horizontally** — logos and backdrops whose intrinsic width exceeds the dialog, and any poster on a tall viewport, spilled out of the preview.
- **The title overflowed** — long monospace cache keys (e.g. `tmdb/123456…`) didn't wrap (default word-break doesn't break at `/`) and could run under the absolutely-positioned close button.

## Fix
All changes are scoped to the preview dialog usage site in `ImageListView.vue` (shared `ui/dialog/*` components and the Fetch modal are untouched):

| Element | Change | Why |
|---|---|---|
| `<img>` | add `max-w-full` | Constrains the image to the dialog width; with `object-contain` it now fits in **both** axes for all kinds/viewports. |
| preview flex container | add `min-w-0` | A grid/flex item's default `min-width: auto` blocks shrinking; this lets `max-w-full` actually take effect. |
| `<DialogTitle>` | add `break-all pr-8 min-w-0` | Long keys wrap at any character and clear the close button (`right-4` + `size-4`), instead of overflowing or colliding. |
| skeleton classes | add `max-w-full` | The fixed-width loading placeholder (`w-[270px]`/`w-[400px]`/`w-[480px]`) no longer overflows narrow viewports. |

The full cache key stays visible (chose `break-all` over `truncate`), since reading the key is the point of the preview header.

## Verification
- `npx vitest run` — **307 passed** (incl. `ImageListView.spec.ts`).
- `vite build` — succeeds (7309 modules).
- E2E specs only assert on headers/counts/buttons/fetch-modal — none touch the preview image's classes, structure, text, or roles, so they're unaffected.
- CSS chain verified for a 16:9 backdrop and a 2:3 poster on a 1440px-tall viewport (object-contain honors whichever of `max-w`/`max-h` binds → fits both axes).

## Out of scope (deliberately)
Issue #58 is specifically about the *image preview*. The fetch-modal error text and the data-table `ID Value` cell are separate surfaces and were left untouched to keep the diff minimal.