### PR TITLE
Pre-release hardening for v1.2.0 (review of v1.1.2..HEAD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,12 +302,12 @@ Cache keys uniquely identify a rendered image. They are used as keys in the in-m
 
 **Poster:**
 ```
-{id_type}/{id_value}{ratings_suffix}{pos_suffix}{style_suffix}{label_suffix}{direction_suffix}{badge_size_suffix}{shape_suffix}{background_suffix}{size_suffix}
+{id_type}/{id_value}{ratings_suffix}{pos_suffix}{style_suffix}{label_suffix}{direction_suffix}{badge_size_suffix}{shape_suffix}{background_suffix}{split_suffix}{fit_suffix}{size_suffix}
 ```
 
 **Fanart poster:**
 ```
-{id_type}/{id_value}{variant}{ratings_suffix}{pos_suffix}{style_suffix}{label_suffix}{direction_suffix}{badge_size_suffix}{shape_suffix}{background_suffix}{size_suffix}
+{id_type}/{id_value}{variant}{ratings_suffix}{pos_suffix}{style_suffix}{label_suffix}{direction_suffix}{badge_size_suffix}{shape_suffix}{background_suffix}{split_suffix}{fit_suffix}{size_suffix}
 ```
 
 **Logo:**
@@ -317,21 +317,24 @@ Cache keys uniquely identify a rendered image. They are used as keys in the in-m
 
 **Backdrop:**
 ```
-{id_type}/{id_value}{kind_prefix}{variant}{ratings_suffix}{pos_suffix}{style_suffix}{label_suffix}{direction_suffix}{badge_size_suffix}{shape_suffix}{background_suffix}{size_suffix}
+{id_type}/{id_value}{kind_prefix}{variant}{ratings_suffix}{pos_suffix}{style_suffix}{label_suffix}{direction_suffix}{badge_size_suffix}{shape_suffix}{background_suffix}{edge_inset_suffix}{size_suffix}
 ```
 
 ### Suffix Reference
 
 | Suffix | Format | Example | Description |
 |---|---|---|---|
-| Ratings | `@{chars}` | `@mil` | Single-char per source, no commas (`m`=MAL, `i`=IMDb, `l`=Letterboxd, `r`=RT, `a`=RT Audience, `c`=Metacritic, `t`=TMDB, `k`=Trakt) |
+| Ratings | `@{chars}` | `@mil` | Single-char per source, no commas (`m`=MAL, `i`=IMDb, `l`=Letterboxd, `r`=RT, `a`=RT Audience, `c`=Metacritic, `t`=TMDB, `k`=Trakt, `d`=MDBList score, `e`=Roger Ebert) |
 | Position | `.p{pos}` | `.pbc`, `.pl` | Poster badge position (`bc`, `tc`, `l`, `r`, `tl`, `tr`, `bl`, `br`) |
 | Badge style | `.s{style}` | `.sh`, `.sv` | `h` = horizontal, `v` = vertical |
 | Label style | `.l{style}` | `.lt`, `.li`, `.lo` | `t` = text labels, `i` = icon labels, `o` = official provider logos |
 | Badge direction | `.d{dir}` | `.dh`, `.dv` | `h` = horizontal, `v` = vertical (resolved from `d` = default) |
 | Badge size | `.b{size}` | `.bm`, `.bxl` | `xs` = extra-small, `s` = small, `m` = medium (default), `l` = large, `xl` = extra-large |
-| Badge shape | `.sh{shape}` | `.shr`, `.shp` | `r` = rounded (default), `p` = pill |
+| Badge shape | `.sh{shape}` | `.shr`, `.shp` | `r` = rounded (default), `p` = pill (the `sh` prefix distinguishes it from the `.s{style}` token above) |
 | Badge background | `.bg{bg}` | `.bgd`, `.bgn` | `d` = default, `k` = dark, `t` = transparent, `n` = none |
+| Split (poster) | `.x1` | `.x1` | Poster badges split onto opposite sides; only present when enabled |
+| Poster fit | `.f{fit}` | `.fc`, `.fp`, `.fb` | `c` = cover, `p` = pad, `b` = blur — `native` (default) emits no token |
+| Edge inset (backdrop) | `.eh{n}` / `.ev{n}` | `.eh8`, `.ev3` | Backdrop ratings inset from the edge by `n`% — `eh` horizontal, `ev` vertical; only the position-relevant axis, only when non-zero |
 | Image size | `.z{size}` | `.zm`, `.zl` | `s` = small, `m` = medium (default), `l` = large, `vl` = very-large |
 
 ### Image Kind Prefixes

--- a/api/.env.example
+++ b/api/.env.example
@@ -7,8 +7,9 @@ TMDB_API_KEY=your_tmdb_v3_api_key
 FANART_API_KEY=your_fanart_api_key
 
 # At least one of OMDB_API_KEY, MDBLIST_API_KEY, or TRAKT_CLIENT_ID must be set for ratings.
-# MDBList is the preferred provider — it covers all 7 rating sources
-# (IMDb, RT Critics, RT Audience, Metacritic, Trakt, Letterboxd, MAL).
+# MDBList is the preferred provider — it covers all 9 rating sources
+# (IMDb, RT Critics, RT Audience, Metacritic, Trakt, Letterboxd, MAL,
+# the MDBList aggregate score, and Roger Ebert).
 # OMDb only covers IMDb, RT Critics, and Metacritic.
 # MDBList API key (recommended) — https://mdblist.com/preferences/
 MDBLIST_API_KEY=your_mdblist_api_key

--- a/api/src/id/mod.rs
+++ b/api/src/id/mod.rs
@@ -219,9 +219,13 @@ async fn resolve_tmdb(id_value: &str, tmdb: &TmdbClient) -> Result<ResolvedId, A
     };
     let details: Details = tmdb.get(&path, &[]).await?;
 
+    // TMDB returns an empty string (not null) for titles it hasn't cross-referenced
+    // to IMDb; treat that as absent so downstream MDBList/Trakt/OMDb lookups take
+    // their TMDB-id fallback or skip cleanly instead of querying with a blank id.
     let imdb_id = details
         .imdb_id
-        .or_else(|| details.external_ids.as_ref().and_then(|e| e.imdb_id.clone()));
+        .or_else(|| details.external_ids.as_ref().and_then(|e| e.imdb_id.clone()))
+        .filter(|s| !s.is_empty());
 
     let tvdb_id = details.external_ids.as_ref().and_then(|e| e.tvdb_id);
 
@@ -292,7 +296,8 @@ async fn resolve_episode_details(
         .await?;
 
     let imdb_id = hint_imdb_id
-        .or_else(|| details.external_ids.as_ref().and_then(|e| e.imdb_id.clone()));
+        .or_else(|| details.external_ids.as_ref().and_then(|e| e.imdb_id.clone()))
+        .filter(|s| !s.is_empty());
     let tvdb_id = details.external_ids.as_ref().and_then(|e| e.tvdb_id);
     let still_path = hint_still_path.or(details.still_path.clone());
 
@@ -673,7 +678,8 @@ async fn resolve_tvdb(tvdb_id: &str, tmdb: &TmdbClient) -> Result<ResolvedId, Ap
         return Ok(ResolvedId {
             imdb_id: details
                 .external_ids
-                .and_then(|e| e.imdb_id),
+                .and_then(|e| e.imdb_id)
+                .filter(|s| !s.is_empty()),
             tmdb_id: tv.id,
             tvdb_id: tvdb_id_num,
             media_type: MediaType::Tv,
@@ -693,7 +699,7 @@ async fn resolve_tvdb(tvdb_id: &str, tmdb: &TmdbClient) -> Result<ResolvedId, Ap
             .get(&format!("/movie/{}", movie.id), &[])
             .await?;
         return Ok(ResolvedId {
-            imdb_id: details.imdb_id,
+            imdb_id: details.imdb_id.filter(|s| !s.is_empty()),
             tmdb_id: movie.id,
             tvdb_id: tvdb_id_num,
             media_type: MediaType::Movie,

--- a/api/src/image/generate.rs
+++ b/api/src/image/generate.rs
@@ -649,8 +649,10 @@ pub fn render_backdrop_sync(
         // Edge insets are a percentage of the canvas dimension, so they stay
         // proportional across image sizes (small/medium/large). The overlay
         // functions only apply each axis on the edge the position anchors to.
-        let inset_pct_x = edge_inset_x.clamp(0, 100) as f32 / 100.0;
-        let inset_pct_y = edge_inset_y.clamp(0, 100) as f32 / 100.0;
+        // Clamp to the same MAX_EDGE_INSET the settings/cache-key paths use so the
+        // rendered inset can never diverge from the value baked into the cache key.
+        let inset_pct_x = crate::services::db::clamp_edge_inset(edge_inset_x) as f32 / 100.0;
+        let inset_pct_y = crate::services::db::clamp_edge_inset(edge_inset_y) as f32 / 100.0;
         let extra_x = (canvas.width() as f32 * inset_pct_x).round() as u32;
         let extra_y = (canvas.height() as f32 * inset_pct_y).round() as u32;
 

--- a/api/src/image/serve.rs
+++ b/api/src/image/serve.rs
@@ -133,6 +133,11 @@ pub fn badge_background_cache_suffix(background: &str) -> String {
 /// tokenized when it actually affects placement: horizontal for left/right
 /// positions, vertical for top/bottom positions.
 pub fn edge_inset_cache_suffix(position: BadgePosition, inset_x: i32, inset_y: i32) -> String {
+    // Clamp to the supported range so an out-of-range stored value can't mint a
+    // cache key (e.g. `.eh80`) that the renderer — which clamps to MAX_EDGE_INSET —
+    // would never actually produce, splitting the cache for identical output.
+    let inset_x = crate::services::db::clamp_edge_inset(inset_x);
+    let inset_y = crate::services::db::clamp_edge_inset(inset_y);
     let mut out = String::new();
     if (position.is_left() || position.is_right()) && inset_x > 0 {
         out.push_str(&format!(".eh{inset_x}"));

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -207,6 +207,10 @@ pub const MIGRATIONS: &[(&str, &str)] = &[
         "duplicate column",
     ),
     (
+        // Frozen historical default — must not change. This only backfills DBs that
+        // predate the column (whose per-key rows already hold a user-set value, so
+        // the column default is never the effective render value). The authoritative
+        // default for new rows is `default_ratings_order()` / `SCHEMA_SQL` above.
         "ALTER TABLE api_key_settings ADD COLUMN ratings_order TEXT NOT NULL DEFAULT 'mal,imdb,lb,rt,rta,mc,tmdb,trakt'",
         "duplicate column",
     ),

--- a/api/src/services/ratings.rs
+++ b/api/src/services/ratings.rs
@@ -394,13 +394,21 @@ async fn fetch_trakt_rating(
         }
     };
 
-    if resp.rating <= 0.0 || resp.votes == 0 {
+    trakt_badge(resp.rating, resp.votes)
+}
+
+/// Build a Trakt rating badge from a raw 0–10 rating and its vote count.
+///
+/// Pure (no I/O) so the percent formatting (`rating * 10`) and the
+/// no-rating/no-votes suppression can be unit-tested without a live Trakt
+/// client. Returns `None` when there's nothing meaningful to show.
+fn trakt_badge(rating: f64, votes: u64) -> Option<RatingBadge> {
+    if rating <= 0.0 || votes == 0 {
         return None;
     }
-
     Some(RatingBadge {
         source: RatingSource::Trakt,
-        value: format!("{:.0}%", resp.rating * 10.0),
+        value: format!("{:.0}%", rating * 10.0),
     })
 }
 
@@ -1055,6 +1063,50 @@ mod tests {
         assert!(mdblist_badges(&resp).is_empty());
     }
 
+    #[test]
+    fn mdblist_badges_suppresses_zero_score_sources() {
+        // A 0 score is MDBList's "no data" sentinel for score-based sources; it
+        // must be dropped rather than rendered as "0%"/"0", matching Ebert and the
+        // aggregate score.
+        let json = r#"{
+            "score": null,
+            "ids": {},
+            "ratings": [
+                { "source": "tomatoes", "value": null, "score": 0, "votes": 0 },
+                { "source": "popcorn", "value": null, "score": 0, "votes": 0 },
+                { "source": "metacritic", "value": null, "score": 0, "votes": 0 },
+                { "source": "trakt", "value": null, "score": 0, "votes": 0 }
+            ]
+        }"#;
+        let resp: MdblistResponse = serde_json::from_str(json).expect("valid mdblist response");
+        assert!(mdblist_badges(&resp).is_empty(), "zero score-based sources are suppressed");
+    }
+
+    // --- trakt_badge (percent formatting + suppression) ---
+
+    #[test]
+    fn trakt_badge_formats_rating_as_percent() {
+        // Trakt returns a 0–10 rating; we render it as a percentage (×10).
+        assert_eq!(trakt_badge(7.5, 1200).map(|b| b.value), Some("75%".to_string()));
+        assert_eq!(trakt_badge(10.0, 5).map(|b| b.value), Some("100%".to_string()));
+        assert_eq!(
+            trakt_badge(8.36, 42).map(|b| b.value),
+            Some("84%".to_string()),
+            "rounds to whole percent"
+        );
+    }
+
+    #[test]
+    fn trakt_badge_suppresses_zero_rating_or_no_votes() {
+        assert!(trakt_badge(0.0, 1000).is_none(), "no rating");
+        assert!(trakt_badge(7.5, 0).is_none(), "no votes");
+    }
+
+    #[test]
+    fn trakt_badge_uses_trakt_source() {
+        assert_eq!(trakt_badge(6.0, 1).map(|b| b.source), Some(RatingSource::Trakt));
+    }
+
     // --- mdblist_lookup_for (issue #14) ---
 
     fn resolved(imdb: Option<&str>, tmdb_id: u64, media_type: MediaType) -> ResolvedId {
@@ -1090,6 +1142,15 @@ mod tests {
     }
 
     #[test]
+    fn mdblist_lookup_falls_back_to_tmdb_when_imdb_empty() {
+        // TMDB returns "" (not null) for titles with no IMDb cross-reference.
+        // An empty id must be treated as absent so the TMDB fallback still fires —
+        // otherwise the anime/no-IMDb case (issue #14) loses every MDBList badge.
+        let r = resolved(Some(""), 1429, MediaType::Tv);
+        assert_eq!(mdblist_lookup_for(&r), Some(MdblistLookup::Tmdb(1429)));
+    }
+
+    #[test]
     fn mdblist_lookup_none_for_episodes() {
         // MDBList has no episode-level ratings regardless of which ids are present.
         let with_imdb = resolved(Some("tt2560140"), 1429, MediaType::Episode);
@@ -1119,7 +1180,10 @@ fn mdblist_lookup_for(resolved: &ResolvedId) -> Option<MdblistLookup<'_>> {
     if resolved.media_type == MediaType::Episode {
         return None;
     }
-    match resolved.imdb_id.as_deref() {
+    // Treat an empty imdb_id as absent. Resolved ids are normalised at the source
+    // (id/mod.rs), but guard here too so the TMDB fallback can never be defeated by
+    // a blank id reaching this function directly.
+    match resolved.imdb_id.as_deref().filter(|s| !s.is_empty()) {
         Some(imdb_id) => Some(MdblistLookup::Imdb(imdb_id)),
         None => Some(MdblistLookup::Tmdb(resolved.tmdb_id)),
     }
@@ -1164,7 +1228,10 @@ fn mdblist_badges(resp: &MdblistResponse) -> Vec<RatingBadge> {
                 source: RatingSource::Imdb,
                 value: format!("{v:.1}"),
             }),
-            "trakt" => r.score.map(|s| RatingBadge {
+            // Score-based sources: suppress a 0 (MDBList's "no data" sentinel),
+            // matching the zero-suppression on Ebert, the aggregate score, and the
+            // direct Trakt/TMDB paths so a missing source never renders as 0%.
+            "trakt" => r.score.filter(|s| *s > 0.0).map(|s| RatingBadge {
                 source: RatingSource::Trakt,
                 value: format!("{:.0}%", s),
             }),
@@ -1172,19 +1239,19 @@ fn mdblist_badges(resp: &MdblistResponse) -> Vec<RatingBadge> {
                 source: RatingSource::Letterboxd,
                 value: format!("{v:.1}"),
             }),
-            "popcorn" => r.score.map(|s| RatingBadge {
+            "popcorn" => r.score.filter(|s| *s > 0.0).map(|s| RatingBadge {
                 source: RatingSource::RtAudience,
                 value: format!("{:.0}%", s),
             }),
-            "tomatoes" => r.score.map(|s| RatingBadge {
+            "tomatoes" => r.score.filter(|s| *s > 0.0).map(|s| RatingBadge {
                 source: RatingSource::Rt,
                 value: format!("{:.0}%", s),
             }),
-            "metacritic" => r.score.map(|s| RatingBadge {
+            "metacritic" => r.score.filter(|s| *s > 0.0).map(|s| RatingBadge {
                 source: RatingSource::Metacritic,
                 value: format!("{:.0}", s),
             }),
-            "myanimelist" => r.score.map(|s| RatingBadge {
+            "myanimelist" => r.score.filter(|s| *s > 0.0).map(|s| RatingBadge {
                 source: RatingSource::Mal,
                 value: format!("{:.2}", s / 10.0),
             }),

--- a/api/src/upgrade/v003_badge_shape_background_cache.rs
+++ b/api/src/upgrade/v003_badge_shape_background_cache.rs
@@ -76,6 +76,10 @@ pub async fn run_fs(cache_dir: &str, external_cache_only: bool) -> Result<(), Ap
     let cache_dir = cache_dir.to_string();
     let renamed = tokio::task::spawn_blocking(move || {
         let mut count = 0u64;
+        // Must cover every rendered image type the DB step touches (run_db is
+        // unfiltered by image_type). If a new image type / cache subdir is ever
+        // added, add it here too — otherwise its DB key migrates but the file is
+        // not renamed and the next request harmlessly regenerates it.
         for subdir in ["posters", "logos", "backdrops", "episodes"] {
             count += rename_files(&std::path::Path::new(&cache_dir).join(subdir))?;
         }

--- a/api/tests/query_overrides.rs
+++ b/api/tests/query_overrides.rs
@@ -392,3 +392,101 @@ async fn poster_ratings_limit_ten_accepted() {
     let res = app.oneshot(req).await.unwrap();
     assert_ne!(res.status(), StatusCode::BAD_REQUEST);
 }
+
+// --- Badge shape / background / split / fit / edge inset query params ---
+
+#[tokio::test]
+async fn poster_badge_shape_and_background_accepted() {
+    let (app, _) = common::setup_test_app().await;
+    let api_key = create_api_key(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/{api_key}/imdb/poster-default/tt0000001.jpg?badge_shape=p&badge_background=k"
+        ))
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_ne!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn poster_split_and_fit_accepted() {
+    let (app, _) = common::setup_test_app().await;
+    let api_key = create_api_key(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/{api_key}/imdb/poster-default/tt0000001.jpg?split=true&fit=cover"
+        ))
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_ne!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn backdrop_edge_inset_accepted() {
+    let (app, _) = common::setup_test_app().await;
+    let api_key = create_api_key(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/{api_key}/imdb/backdrop-default/tt0000001.jpg?edge_inset_x=8&edge_inset_y=3&position=bl"
+        ))
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_ne!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn poster_invalid_badge_shape_rejected() {
+    let (app, _) = common::setup_test_app().await;
+    let api_key = create_api_key(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/{api_key}/imdb/poster-default/tt0000001.jpg?badge_shape=z"
+        ))
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn poster_invalid_badge_background_rejected() {
+    let (app, _) = common::setup_test_app().await;
+    let api_key = create_api_key(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/{api_key}/imdb/poster-default/tt0000001.jpg?badge_background=z"
+        ))
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn poster_invalid_fit_rejected() {
+    let (app, _) = common::setup_test_app().await;
+    let api_key = create_api_key(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/{api_key}/imdb/poster-default/tt0000001.jpg?fit=bogus"
+        ))
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,13 @@ services:
       TMDB_API_KEY: ${TMDB_API_KEY:?Set TMDB_API_KEY in .env}
       JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET in .env — generate with: openssl rand -hex 32}
 
-      # At least one ratings source is required — MDBList is preferred (covers all 7 rating sources)
+      # At least one ratings source (MDBList, OMDb, or Trakt) is required —
+      # MDBList is preferred (covers 9 rating sources)
       MDBLIST_API_KEY: ${MDBLIST_API_KEY:-}
       # OMDb is also required for IMDB episode ratings (MDBList does not support episode-level ratings)
       OMDB_API_KEY: ${OMDB_API_KEY:-}
+      # Trakt Client ID — Trakt community ratings for movies, shows, and episodes
+      TRAKT_CLIENT_ID: ${TRAKT_CLIENT_ID:-}
 
       # Optional — enables Fanart.tv as an alternative or preferred image source
       FANART_API_KEY: ${FANART_API_KEY:-}

--- a/web/src/__tests__/views/SettingsView.spec.ts
+++ b/web/src/__tests__/views/SettingsView.spec.ts
@@ -39,6 +39,8 @@ const defaultSettings = {
   poster_badge_split: false,
   backdrop_position: 'tr',
   backdrop_badge_direction: 'v',
+  backdrop_edge_inset_x: 0,
+  backdrop_edge_inset_y: 0,
   episode_ratings_limit: 1,
   episode_badge_style: 'v',
   episode_label_style: 'o',
@@ -374,6 +376,41 @@ describe('SettingsView', () => {
         episode_position: 'tr',
         episode_badge_direction: 'v',
         episode_blur: false,
+      }),
+    )
+  })
+
+  it('toggleFreeApiKey payload preserves backdrop position, direction, and edge insets', async () => {
+    // Regression guard: the toggle must forward the full settings, not a curated
+    // subset. A previous payload omitted these backdrop fields, so flipping the
+    // free-key switch silently reset them to their serde defaults on the server.
+    mockAdminApi.getSettings.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          ...defaultSettings,
+          backdrop_position: 'bl',
+          backdrop_badge_direction: 'h',
+          backdrop_edge_inset_x: 12,
+          backdrop_edge_inset_y: 7,
+        }),
+    })
+    mockAdminApi.updateSettings.mockResolvedValue({ ok: true })
+
+    const wrapper = mountView()
+    await flushPromises()
+
+    const toggle = wrapper.find('button[role="switch"]')
+    await toggle.trigger('click')
+    await flushPromises()
+
+    expect(mockAdminApi.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        free_api_key_enabled: true,
+        backdrop_position: 'bl',
+        backdrop_badge_direction: 'h',
+        backdrop_edge_inset_x: 12,
+        backdrop_edge_inset_y: 7,
       }),
     )
   })

--- a/web/src/components/RenderSettingsForm.vue
+++ b/web/src/components/RenderSettingsForm.vue
@@ -195,6 +195,13 @@ function revertEdits() {
 
 let pendingSave = false
 
+// An emptied `v-model.number` input yields '' (and a partial entry can yield a
+// non-integer); the backend types edge insets as a required i32, so send a clean,
+// clamped integer to avoid a 400 mid-edit. Matches the server's 0–50 clamp.
+function coerceInset(value: number): number {
+  return Number.isFinite(value) ? Math.min(50, Math.max(0, Math.round(value))) : 0
+}
+
 async function autoSave() {
   if (saving.value) {
     pendingSave = true
@@ -229,8 +236,8 @@ async function autoSave() {
       backdrop_badge_size: editBackdropBadgeSize.value,
       backdrop_position: editBackdropPosition.value,
       backdrop_badge_direction: editBackdropBadgeDirection.value,
-      backdrop_edge_inset_x: editBackdropEdgeInsetX.value,
-      backdrop_edge_inset_y: editBackdropEdgeInsetY.value,
+      backdrop_edge_inset_x: coerceInset(editBackdropEdgeInsetX.value),
+      backdrop_edge_inset_y: coerceInset(editBackdropEdgeInsetY.value),
       episode_ratings_limit: editEpisodeRatingsLimit.value,
       episode_badge_style: editEpisodeBadgeStyle.value,
       episode_label_style: editEpisodeLabelStyle.value,

--- a/web/src/views/SettingsView.vue
+++ b/web/src/views/SettingsView.vue
@@ -48,44 +48,13 @@ async function toggleFreeApiKey() {
   freeKeyLoading.value = true
   freeKeyError.value = ''
   const newVal = !freeApiKeyEnabled.value
-  const s = settings.value
+  // Forward the full settings unchanged (admin update is a full replace where every
+  // omitted field is written back as its serde default). Spreading guards against
+  // silently resetting any field not explicitly listed — e.g. backdrop position,
+  // direction, and edge insets. The read-only free_api_key_locked field is ignored
+  // by the backend.
   const res = await adminApi.updateSettings({
-    image_source: s.image_source,
-    lang: s.lang,
-    textless: s.textless,
-    ratings_limit: s.ratings_limit,
-    ratings_order: s.ratings_order,
-    ratings_exclude: s.ratings_exclude,
-    poster_position: s.poster_position,
-    logo_ratings_limit: s.logo_ratings_limit,
-    backdrop_ratings_limit: s.backdrop_ratings_limit,
-    poster_badge_style: s.poster_badge_style,
-    logo_badge_style: s.logo_badge_style,
-    backdrop_badge_style: s.backdrop_badge_style,
-    poster_label_style: s.poster_label_style,
-    logo_label_style: s.logo_label_style,
-    backdrop_label_style: s.backdrop_label_style,
-    poster_badge_direction: s.poster_badge_direction,
-    poster_badge_split: s.poster_badge_split,
-    poster_fit: s.poster_fit,
-    poster_badge_size: s.poster_badge_size,
-    logo_badge_size: s.logo_badge_size,
-    backdrop_badge_size: s.backdrop_badge_size,
-    episode_ratings_limit: s.episode_ratings_limit,
-    episode_badge_style: s.episode_badge_style,
-    episode_label_style: s.episode_label_style,
-    episode_badge_size: s.episode_badge_size,
-    episode_position: s.episode_position,
-    episode_badge_direction: s.episode_badge_direction,
-    episode_blur: s.episode_blur,
-    poster_badge_shape: s.poster_badge_shape,
-    logo_badge_shape: s.logo_badge_shape,
-    backdrop_badge_shape: s.backdrop_badge_shape,
-    episode_badge_shape: s.episode_badge_shape,
-    poster_badge_background: s.poster_badge_background,
-    logo_badge_background: s.logo_badge_background,
-    backdrop_badge_background: s.backdrop_badge_background,
-    episode_badge_background: s.episode_badge_background,
+    ...settings.value,
     free_api_key_enabled: newVal,
   })
   if (res.ok) {


### PR DESCRIPTION
Fixes surfaced by a thorough review of everything since **v1.1.2** (49 commits, 71 files: Trakt/MDBList-score/Ebert ratings, `ratings_exclude`, badge shapes/backgrounds, split badges, poster fit, backdrop edge insets, v003 cache migration). No hard blockers were found in the released code itself; these are the actionable issues worth fixing before tagging **v1.2.0**.

## Fix-before-release

**1. `docker-compose.yml` never forwarded `TRAKT_CLIENT_ID`** (was HIGH)
The compose file is the documented primary install path but only passed TMDB/MDBLIST/OMDB/FANART. A user setting `TRAKT_CLIENT_ID` in `.env` silently got no Trakt ratings, and a **Trakt-only deploy hard-panicked at startup** (none of OMDB/MDBLIST/TRAKT reached the container). Added the env var + refreshed the stale "7 rating sources" comment.

**2. Empty-string `imdb_id` defeated the new MDBList TMDB fallback (#14)** (was MEDIUM)
TMDB returns `""` (not null) for no-IMDb titles — exactly the anime case #14 targets. `resolved.imdb_id` was `Some("")`, which queried the IMDb-keyed MDBList endpoint with a blank id, 404'd, and dropped **every** badge. Now normalised to `None` at the source (`id/mod.rs`, all 4 build sites) with a defensive guard in `mdblist_lookup_for`. New test covers `Some("")`.

**3. Toggling the Free API Key wiped backdrop settings** (was MEDIUM, new regression)
The admin PUT is a full replace; the curated toggle payload omitted `backdrop_position`, `backdrop_badge_direction`, and the **new** `backdrop_edge_inset_x/y`, silently resetting them to defaults. Now spreads the full settings so no field can be dropped. New regression-guard test.

## Polish (also included)

- **Backdrop edge-inset clamp** — cache-key suffix used the raw value while the renderer clamped to 100 (not the enforced `MAX_EDGE_INSET` of 50); aligned both to `clamp_edge_inset` so the key and rendered output can't diverge.
- **Clearing an inset input** now coerces to a clamped integer before saving (the field is `i32` server-side, so `""` or `12.5` previously 400'd mid-edit).
- **Zero-score MDBList sources** (rt/popcorn/metacritic/trakt) now suppressed, matching the existing Ebert/aggregate/TMDB/direct-Trakt behaviour.
- **Trakt badge formatting** extracted into a pure, unit-tested `trakt_badge()` (guards the `rating * 10` percent conversion against a 10× regression — it had zero tests).
- **Tests/docs**: HTTP accept/reject coverage for `?badge_shape/?badge_background/?split/?fit/?edge_inset`; README cache-key suffix table updated (`d`/`e` ratings chars, `.x1`/`.fc`/`.fp`/`.fb`/`.eh`/`.ev`); `.env.example` 9-source count; v003 subdir + frozen-`ratings_order`-default comments.

## Deliberately deferred (call-outs, not in this PR)
- **New badges on long-cached titles**: pre-existing titles older than `ratings_max_age_secs` won't show the new MDBList/Ebert/Trakt badges until evicted (no `available_ratings` invalidation was added). Default-settings users are unaffected (these sit at order positions 8–10, beyond the default limit of 3). A catalogue-wide re-resolve is a behaviour decision — worth a release note rather than a silent migration.

## Validation (all four CI gates pass locally)
- `cargo test` — **467** lib tests + all integration suites green (10 new tests)
- `vitest run` — **308** tests green (incl. new SettingsView regression guard)
- `vite build` (build-only) — ✓
- `cargo check --release --features test-support` — ✓

## Release reminder
Version files still read `1.1.2` — that's expected; `scripts/release.sh 1.2.0` performs the bump + tag + GitHub release (which triggers the image build). Merge this first, then run the release script.