### PR TITLE
fix(release): make release.sh version bump portable on macOS

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,8 +31,16 @@ fi
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 
-# Update Cargo.toml version
-sed -i "0,/^version = \".*\"/s//version = \"$VERSION\"/" "$REPO_ROOT/api/Cargo.toml"
+# Update Cargo.toml version — rewrite the first `version = "..."` line (the
+# [package] version; dependency versions are inline and don't start a line).
+# Uses awk for portability: BSD/macOS sed rejects `sed -i` without a suffix and
+# the GNU-only `0,/re/` address form.
+cargo_toml="$REPO_ROOT/api/Cargo.toml"
+tmp="$(mktemp)"
+awk -v ver="$VERSION" '
+    !done && /^version = "/ { sub(/"[^"]*"/, "\"" ver "\""); done = 1 }
+    { print }
+' "$cargo_toml" > "$tmp" && mv "$tmp" "$cargo_toml"
 
 # Update Cargo.lock
 (cd "$REPO_ROOT/api" && cargo update --workspace)


### PR DESCRIPTION
`./scripts/release.sh <version>` fails on macOS with:

```
sed: 1: "/Users/lily/Repos/openp ...": extra characters at the end of l command
```

BSD/macOS `sed` rejects both `sed -i` without a backup suffix and the GNU-only `0,/re/` address form used to bump the `[package]` version in `api/Cargo.toml`. The script exits via `set -euo pipefail` before any version bump, commit, tag, or release — so a failed run leaves the tree clean (no partial state).

**Fix:** rewrite the first `version = "..."` line with `awk` instead — portable across BSD and GNU, still scoped to the `[package]` version (dependency versions are inline `{ version = ... }` and don't start a line, so they're untouched).

Verified on macOS: the dry-run bumps `version = "1.2.0"` and leaves `tokio`/`serde` dependency versions unchanged; `bash -n` passes.

Needed to unblock cutting **v1.2.0** (the version bump must run before the release commit/tag).