### PR TITLE
fix(trakt): send User-Agent so Cloudflare stops 403-blocking ratings

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -49,11 +49,26 @@ impl std::fmt::Debug for Config {
     }
 }
 
+/// Read an optional secret env var, trimming surrounding whitespace and treating
+/// an empty (or whitespace-only) value as absent.
+///
+/// Without this a blank or whitespace/CR/quote-contaminated value (a common
+/// deployment foot-gun: CRLF `.env` files, mis-quoted shell) would still be
+/// `Some(_)` and construct a live client that sends a junk key on every request.
+/// For Trakt that surfaces as a 403 on *every* title rather than the provider
+/// simply being disabled.
+fn optional_secret(key: &str) -> Option<String> {
+    env::var(key)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
 impl Config {
     pub fn from_env() -> Self {
         let config = Self {
             tmdb_api_key: env::var("TMDB_API_KEY").expect("TMDB_API_KEY must be set"),
-            omdb_api_key: env::var("OMDB_API_KEY").ok(),
+            omdb_api_key: optional_secret("OMDB_API_KEY"),
             cache_dir: env::var("CACHE_DIR").unwrap_or_else(|_| "./cache".into()),
             db_dir: env::var("DB_DIR").unwrap_or_else(|_| "./db".into()),
             listen_addr: env::var("LISTEN_ADDR").unwrap_or_else(|_| "0.0.0.0:3000".into()),
@@ -73,15 +88,15 @@ impl Config {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(85),
-            mdblist_api_key: env::var("MDBLIST_API_KEY").ok(),
+            mdblist_api_key: optional_secret("MDBLIST_API_KEY"),
             image_mem_cache_mb: env::var("IMAGE_MEM_CACHE_MB")
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(512),
             static_dir: env::var("STATIC_DIR").ok(),
             cors_origin: env::var("CORS_ORIGIN").ok(),
-            fanart_api_key: env::var("FANART_API_KEY").ok(),
-            trakt_client_id: env::var("TRAKT_CLIENT_ID").ok(),
+            fanart_api_key: optional_secret("FANART_API_KEY"),
+            trakt_client_id: optional_secret("TRAKT_CLIENT_ID"),
             enable_cdn_redirects: env::var("ENABLE_CDN_REDIRECTS")
                 .map(|v| v == "true" || v == "1")
                 .unwrap_or(false),
@@ -179,6 +194,24 @@ mod tests {
         let cfg = Config::from_env();
         assert!(cfg.omdb_api_key.is_none());
         assert_eq!(cfg.mdblist_api_key.as_deref(), Some("mdblist_test"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_optional_secret_trims_and_drops_empty() {
+        unsafe { clear_config_env() };
+        unsafe { env::set_var("TMDB_API_KEY", "tmdb_test") };
+        // A whitespace-padded value is trimmed (CRLF .env / mis-quoted shell).
+        unsafe { env::set_var("OMDB_API_KEY", "  omdb_test  ") };
+        // Empty / whitespace-only optional keys are treated as absent so they
+        // never build a client that 403s on every request (the Trakt symptom).
+        unsafe { env::set_var("MDBLIST_API_KEY", "") };
+        unsafe { env::set_var("TRAKT_CLIENT_ID", "   ") };
+
+        let cfg = Config::from_env();
+        assert_eq!(cfg.omdb_api_key.as_deref(), Some("omdb_test"), "value is trimmed");
+        assert!(cfg.mdblist_api_key.is_none(), "empty key treated as absent");
+        assert!(cfg.trakt_client_id.is_none(), "whitespace-only key treated as absent");
     }
 
     #[test]

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -35,6 +35,14 @@ async fn main() {
 
     let config = Config::from_env();
     let http = reqwest::Client::builder()
+        // Trakt requires a User-Agent and fronts its API with a Cloudflare WAF
+        // that returns 403 to requests without one; reqwest sends none by default.
+        // Identify ourselves on every outbound provider call.
+        .user_agent(concat!(
+            "openposterdb/",
+            env!("CARGO_PKG_VERSION"),
+            " (+https://github.com/PNRxA/openposterdb)"
+        ))
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
         .build()


### PR DESCRIPTION
## Problem

Trakt rating fetches were failing with a uniform **403 Forbidden** on every movie and show:

```
WARN trakt rating fetch failed: API error: HTTP status client error
(403 Forbidden) for url (https://api.trakt.tv/movies/tt0013442/ratings)
```

This is **not a logic bug** — the request headers, 404→`None` handling, and retry layer (`retry.rs` correctly does not retry 403s) are all fine, and the error already degrades gracefully.

## Root cause

The shared `reqwest::Client` (`api/src/main.rs`) was built with only `.timeout()`/`.connect_timeout()` — **no `User-Agent`**, and reqwest 0.13.2 sends none by default. Trakt documents `User-Agent` as a required header and fronts `api.trakt.tv` with a Cloudflare WAF that returns a uniform 403 ("Sorry, you have been blocked") to UA-less requests — a well-documented, recurring 2025–2026 issue (Trakt forums #50946 / #105444, GitHub `trakt/trakt-api` #507 / #740).

Because that one client is shared across all providers, only Trakt — the one that enforces a UA — failed, with an identical 403 on every title, matching the log flood exactly.

## Changes

- **`api/src/main.rs`** — set a descriptive `User-Agent` on the client builder (`openposterdb/<version> (+repo)`), fixing every outbound provider call.
- **`api/src/config.rs`** — add an `optional_secret()` helper that trims and treats empty/whitespace as absent, applied to `OMDB`/`MDBLIST`/`FANART`/`TRAKT` keys. Previously a blank or CRLF/quote-contaminated `TRAKT_CLIENT_ID` was still `Some(_)` and built a client that sent a junk key and 403'd on every title; now the provider is cleanly disabled instead. Adds `test_optional_secret_trims_and_drops_empty`.

## Verifying

Run from the production host, once without `-A` and once with it (`tt0111161` avoids a 404):

```bash
curl -sS -i -A 'openposterdb/1.2.0 (+https://github.com/PNRxA/openposterdb)' \
  -H 'Content-Type: application/json' -H 'trakt-api-version: 2' \
  -H 'trakt-api-key: <TRAKT_CLIENT_ID>' \
  https://api.trakt.tv/movies/tt0111161/ratings
```

- 403 without `-A` → 200 with `-A` confirms the missing-UA cause this PR fixes.
- 403 HTML + `cf-ray` even **with** `-A` → datacenter IP is edge-blocked (needs an egress proxy / different host, out of scope here).
- 403 JSON `"invalid API key or unapproved app"` → check `TRAKT_CLIENT_ID` and the app at https://trakt.tv/oauth/applications.

## Tests

`cargo test --lib` (468 passed) and `cargo build --bin openposterdb-api` both green.