### PR TITLE
fix(image): preserve client error status from cache under concurrent requests

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use serde_json::json;
@@ -36,6 +38,35 @@ pub enum AppError {
 
     #[error("{0}")]
     Other(String),
+}
+
+impl AppError {
+    /// Recover a typed `AppError` from moka's `Arc`-wrapped cache error.
+    ///
+    /// `moka`'s `try_get_with` returns the init closure's error as
+    /// `Arc<AppError>`, and on concurrent calls for the same key it hands
+    /// every waiter a *clone* of that `Arc`. Calling `Arc::try_unwrap` then
+    /// fails for all waiters (strong count > 1), so naively collapsing the
+    /// `Err` arm to [`AppError::Other`] turns a client-facing 404/400 into a
+    /// spurious 500 whenever requests race. Reconstruct the client-facing
+    /// variants by reference instead so the HTTP status is preserved; only
+    /// genuinely-internal variants (which are 500 regardless) collapse to
+    /// [`AppError::Other`].
+    pub fn from_cached(arc: Arc<AppError>) -> AppError {
+        // Sole owner (no concurrent waiters): move the exact error out,
+        // preserving full detail for internal variants too.
+        match Arc::try_unwrap(arc) {
+            Ok(err) => err,
+            Err(arc) => match arc.as_ref() {
+                AppError::InvalidIdType(msg) => AppError::InvalidIdType(msg.clone()),
+                AppError::IdNotFound(msg) => AppError::IdNotFound(msg.clone()),
+                AppError::BadRequest(msg) => AppError::BadRequest(msg.clone()),
+                AppError::Forbidden(msg) => AppError::Forbidden(msg.clone()),
+                AppError::Unauthorized => AppError::Unauthorized,
+                other => AppError::Other(other.to_string()),
+            },
+        }
+    }
 }
 
 impl IntoResponse for AppError {
@@ -143,5 +174,37 @@ mod tests {
     async fn client_errors_preserve_message() {
         let body = body_of(AppError::BadRequest("missing field".into())).await;
         assert_eq!(body["error"], "missing field");
+    }
+
+    #[test]
+    fn from_cached_sole_owner_preserves_variant() {
+        let arc = Arc::new(AppError::IdNotFound("no logo available".into()));
+        assert_eq!(
+            status_of(AppError::from_cached(arc)),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn from_cached_shared_arc_preserves_client_status() {
+        // The concurrent-waiter case: moka hands each waiter a clone of the
+        // same Arc, so strong_count > 1 and Arc::try_unwrap fails. This must
+        // still yield a 404, not a spurious 500.
+        let arc = Arc::new(AppError::IdNotFound("no logo available".into()));
+        let _waiter = arc.clone();
+        assert_eq!(
+            status_of(AppError::from_cached(arc)),
+            StatusCode::NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn from_cached_shared_arc_collapses_internal_to_500() {
+        let arc = Arc::new(AppError::DbError("connection refused".into()));
+        let _waiter = arc.clone();
+        assert_eq!(
+            status_of(AppError::from_cached(arc)),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 }

--- a/api/src/id/mod.rs
+++ b/api/src/id/mod.rs
@@ -116,14 +116,7 @@ pub async fn resolve(
             }
         })
         .await
-        .map_err(|arc_err| match arc_err.as_ref() {
-            AppError::InvalidIdType(msg) => AppError::InvalidIdType(msg.clone()),
-            AppError::IdNotFound(msg) => AppError::IdNotFound(msg.clone()),
-            AppError::BadRequest(msg) => AppError::BadRequest(msg.clone()),
-            AppError::Unauthorized => AppError::Unauthorized,
-            AppError::Forbidden(msg) => AppError::Forbidden(msg.clone()),
-            other => AppError::Other(other.to_string()),
-        })
+        .map_err(AppError::from_cached)
 }
 
 async fn resolve_imdb(imdb_id: &str, tmdb: &TmdbClient) -> Result<ResolvedId, AppError> {

--- a/api/src/image/serve.rs
+++ b/api/src/image/serve.rs
@@ -856,10 +856,7 @@ pub async fn handle_inner(
             Ok::<_, AppError>(bytes)
         })
         .await
-        .map_err(|e| match Arc::try_unwrap(e) {
-            Ok(app_err) => app_err,
-            Err(arc) => AppError::Other(arc.to_string()),
-        })?;
+        .map_err(AppError::from_cached)?;
 
     let total_ms = request_start.elapsed().as_millis() as u64;
     if total_ms > SLOW_REQUEST_MS {
@@ -1786,10 +1783,7 @@ pub async fn handle_episode_inner(
             Ok::<_, AppError>(bytes)
         })
         .await
-        .map_err(|e| match Arc::try_unwrap(e) {
-            Ok(app_err) => app_err,
-            Err(arc) => AppError::Other(arc.to_string()),
-        })?;
+        .map_err(AppError::from_cached)?;
     state
         .image_mem_cache
         .insert(cache_key, MemCacheEntry { bytes: bytes.clone(), last_checked: Instant::now() })
@@ -2057,10 +2051,7 @@ pub async fn handle_logo_backdrop_inner(
             Ok::<_, AppError>(bytes)
         })
         .await
-        .map_err(|e| match Arc::try_unwrap(e) {
-            Ok(app_err) => app_err,
-            Err(arc) => AppError::Other(arc.to_string()),
-        })?;
+        .map_err(AppError::from_cached)?;
 
     state
         .image_mem_cache


### PR DESCRIPTION
## What

Fixes spurious `500 Internal Server Error` responses (and matching ERROR-level log noise) for image requests that should be `404`/`400`, seen in prod as:

```
ERROR openposterdb_api::error: status=500 Internal Server Error error=id not found: no logo available
```

## Root cause

Image requests are de-duplicated through moka's `try_get_with`, which returns the init closure's error as `Arc<AppError>`. On **concurrent calls for the same key**, moka hands every waiter a *clone* of that `Arc`, so `Arc::try_unwrap` fails (strong count > 1) and the `Err` arm collapsed the error to `AppError::Other` → **500**.

A single request for a title with no logo correctly returns **404**; it only flipped to 500 when several identical requests raced (the inflight herd) — exactly when the `Arc` is shared. The same buggy `Arc::try_unwrap` pattern existed in the **poster** (`handle_inner`), **episode** (`handle_episode_inner`), and **logo/backdrop** (`handle_logo_backdrop_inner`) serve paths.

No info leak (the body was already redacted to `"Internal server error"`), but the wrong status code creates ERROR-log/alerting noise and defeats CDN/client negative-caching of 404s — letting the herd repeat.

## Fix

- Add `AppError::from_cached(Arc<AppError>)` in `error.rs`: moves the error out when it is the sole owner, otherwise rebuilds the client-facing variants (`IdNotFound`, `InvalidIdType`, `BadRequest`, `Forbidden`, `Unauthorized`) by reference so the HTTP status is preserved; only genuinely-internal variants collapse to `Other` (which are 500 regardless).
- Use it at all three image serve sites.
- Replace the hand-rolled equivalent in `id::resolve` (which already did this correctly) with the shared helper, so the logic can't drift again.
- Add regression tests for the shared-`Arc` case (404 preserved; internal → 500).

## Testing

- `cargo test --lib` — 471 passed, including 3 new `from_cached_*` tests.
- `cargo clippy --lib` — no new warnings (remaining warnings are pre-existing and unrelated).