### PR TITLE
fix(logging): stop API keys leaking into logs via reqwest error URLs

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -22,7 +22,7 @@ pub enum AppError {
     BadRequest(String),
 
     #[error("API error: {0}")]
-    Api(#[from] reqwest::Error),
+    Api(#[source] reqwest::Error),
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
@@ -66,6 +66,33 @@ impl AppError {
                 other => AppError::Other(other.to_string()),
             },
         }
+    }
+}
+
+/// Strip the query string from a reqwest error's embedded URL.
+///
+/// reqwest stores the full request URL — including the query string — inside its
+/// errors and renders it in both `Display` and `Debug` (`… for url (…)`). Our
+/// upstream clients pass API keys as query parameters (`?api_key=…` / `?apikey=…`
+/// for TMDB, OMDb, MDBList, fanart), so an upstream 404/timeout/decode error
+/// would otherwise leak the key into the logs. Dropping the query keeps the
+/// scheme/host/path — useful for debugging and never secret — while removing the
+/// credential. Trakt sends its key as a header, which reqwest never embeds, so it
+/// is unaffected.
+///
+/// Applied at every boundary where a `reqwest::Error` becomes loggable: the
+/// `From` impl below (covers every `?`/`error_for_status()?` site) and the
+/// direct construction in `services::retry`.
+pub(crate) fn redact_url_secrets(mut err: reqwest::Error) -> reqwest::Error {
+    if let Some(url) = err.url_mut() {
+        url.set_query(None);
+    }
+    err
+}
+
+impl From<reqwest::Error> for AppError {
+    fn from(err: reqwest::Error) -> Self {
+        AppError::Api(redact_url_secrets(err))
     }
 }
 
@@ -206,5 +233,50 @@ mod tests {
             status_of(AppError::from_cached(arc)),
             StatusCode::INTERNAL_SERVER_ERROR
         );
+    }
+
+    #[tokio::test]
+    async fn api_error_strips_api_key_from_url() {
+        // Regression for the MDBList `?apikey=…` key leaking into logs: reqwest
+        // embeds the full request URL (query string included) in its error, and
+        // we format `AppError::Api` straight into the logs. Converting through
+        // `From<reqwest::Error>` must drop the query so the key can't escape.
+        //
+        // A local server returns 404 so `error_for_status()` produces exactly the
+        // error shape seen in production (`HTTP status … for url (…?apikey=…)`),
+        // with no external network so the test stays deterministic.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        // An empty router 404s every path — all we need to drive `error_for_status`.
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, axum::Router::new()).await;
+        });
+
+        let url = format!("http://{addr}/imdb/show/tt33306109?apikey=SUPERSECRETKEY");
+        let raw = reqwest::Client::new()
+            .get(&url)
+            .send()
+            .await
+            .expect("request reaches the local server")
+            .error_for_status()
+            .expect_err("server returns 404");
+
+        // Sanity-check that reqwest really leaks the key by default; otherwise this
+        // test could pass vacuously and never catch a regression.
+        let unsanitized = format!("{raw}");
+        assert!(
+            unsanitized.contains("SUPERSECRETKEY"),
+            "precondition: reqwest is expected to embed the key in its error, got: {unsanitized}"
+        );
+
+        let app: AppError = raw.into();
+        let display = format!("{app}");
+        let debug = format!("{app:?}");
+        for rendered in [&display, &debug] {
+            assert!(!rendered.contains("SUPERSECRETKEY"), "api key leaked: {rendered}");
+            assert!(!rendered.contains("apikey"), "query string leaked: {rendered}");
+        }
+        // The non-secret host/path is preserved so failures are still debuggable.
+        assert!(display.contains(&addr.to_string()), "host should be kept: {display}");
     }
 }

--- a/api/src/services/retry.rs
+++ b/api/src/services/retry.rs
@@ -120,6 +120,10 @@ where
                 return Ok(resp);
             }
             Err(e) => {
+                // Strip the API key from the request URL before it reaches the
+                // logs or the wrapped error (reqwest embeds the full URL, query
+                // string included, in its Display). See `error::redact_url_secrets`.
+                let e = crate::error::redact_url_secrets(e);
                 if attempt == config.max_retries {
                     tracing::warn!(
                         service = config.service_name,


### PR DESCRIPTION
## Problem

reqwest embeds the **full request URL — query string included** — in both the `Display` and `Debug` of its `Error` type. TMDB, OMDb, MDBList, and fanart all send their API key as a query parameter (`?api_key=…` / `?apikey=…`), so any upstream failure (404 / timeout / decode error) logged through `AppError::Api` leaked the key into the logs. Observed in production:

```
WARN openposterdb_api::services::ratings: mdblist rating fetch failed: API error:
HTTP status client error (404 Not Found) for url
(https://api.mdblist.com/imdb/show/tt33306109?apikey=<REAL_KEY>)
```

## Fix

Sanitize the **error object itself** at the only two `AppError::Api` construction sites, dropping the URL's query string via `set_query(None)`:

- `From<reqwest::Error> for AppError` — covers every `?` / `error_for_status()?` / `.json()?` path in the service clients.
- The direct `AppError::Api(e)` build in `services::retry`, which also logs the raw error `{e}` on connection failures — sanitized before both the log and the wrap.

Scrubbing the stored error (rather than overriding a single `Display` site) also protects:
- **Debug** output (`?e` / structured fields) — reqwest embeds the URL there too.
- The moka `Arc<AppError>` → `AppError::Other(arc.to_string())` laundering paths in `image::serve`, which re-materialize the inner error's string.

Scheme/host/path are preserved (useful for debugging, never secret). **Trakt** sends its key as a header, which reqwest never embeds, so it's unaffected.

## Verification

- New regression test `api_error_strips_api_key_from_url`: drives a real `error_for_status()` 404 against a local server, asserts reqwest leaks the key **by default** (so the test can't pass vacuously), then asserts the converted `AppError` exposes it in **neither `Display` nor `Debug`**, while keeping host/path.
- A multi-agent secret-leak audit (5 independent lenses — reqwest-error logs, URL-string logs, Debug of secret structs, other secrets, response/panic — with adversarial verification of every candidate) found **zero remaining real, reachable leaks** after this change. It also confirmed non-leaks: Trakt (header key), keyless TMDB/fanart CDN URLs, the redacting `Config` Debug impl, generic 5xx response bodies, and redacted request-trace spans.
- Full backend `cargo test` (the CI gate) green: 469 lib + all integration binaries, 0 failures. No new clippy warnings in the changed files.

## Files

- `api/src/error.rs` — `redact_url_secrets` helper + manual `From<reqwest::Error>`; `#[from]` → `#[source]`; regression test.
- `api/src/services/retry.rs` — redact the transport error before it is logged or wrapped.