### PR TITLE
Add MDBList age-rating badge feature

### DIFF
--- a/api/src/entity/api_key_settings.rs
+++ b/api/src/entity/api_key_settings.rs
@@ -49,6 +49,12 @@ pub struct Model {
     /// Distance (percent of height, 0–50) to inset backdrop ratings from the
     /// anchored vertical edge (top or bottom). Ignored for centered positions.
     pub backdrop_edge_inset_y: i32,
+    /// Whether to overlay a CSM age-rating badge on posters.
+    pub csm_enabled: bool,
+    /// Corner of the poster where the CSM badge is anchored (e.g. "TopRight").
+    pub csm_position: String,
+    /// Size of the CSM badge (e.g. "Medium").
+    pub csm_size: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/api/src/handlers/admin.rs
+++ b/api/src/handlers/admin.rs
@@ -153,6 +153,9 @@ pub struct GlobalSettingsResponse {
     pub logo_badge_background: BadgeBackground,
     pub backdrop_badge_background: BadgeBackground,
     pub episode_badge_background: BadgeBackground,
+    pub csm_enabled: bool,
+    pub csm_position: BadgePosition,
+    pub csm_size: BadgeSize,
 }
 
 pub async fn get_settings(
@@ -213,6 +216,9 @@ pub async fn get_settings(
         logo_badge_background: settings.logo_badge_background,
         backdrop_badge_background: settings.backdrop_badge_background,
         episode_badge_background: settings.episode_badge_background,
+        csm_enabled: settings.csm_enabled,
+        csm_position: settings.csm_position,
+        csm_size: settings.csm_size,
     }))
 }
 
@@ -299,6 +305,12 @@ pub struct UpdateGlobalSettingsRequest {
     pub backdrop_badge_background: BadgeBackground,
     #[serde(default = "db::default_badge_background")]
     pub episode_badge_background: BadgeBackground,
+    #[serde(default)]
+    pub csm_enabled: bool,
+    #[serde(default = "db::default_csm_position")]
+    pub csm_position: BadgePosition,
+    #[serde(default = "db::default_csm_size")]
+    pub csm_size: BadgeSize,
 }
 
 pub async fn update_settings(
@@ -315,6 +327,7 @@ pub async fn update_settings(
     let poster_badge_split_str = if req.poster_badge_split { "true" } else { "false" };
     let backdrop_edge_inset_x_str = db::clamp_edge_inset(req.backdrop_edge_inset_x).to_string();
     let backdrop_edge_inset_y_str = db::clamp_edge_inset(req.backdrop_edge_inset_y).to_string();
+    let csm_enabled_str = if req.csm_enabled { "true" } else { "false" };
     let mut batch: Vec<(&str, &str)> = vec![
         ("image_source", req.image_source.as_str()),
         ("lang", &req.lang),
@@ -356,6 +369,9 @@ pub async fn update_settings(
         ("logo_badge_background", req.logo_badge_background.as_str()),
         ("backdrop_badge_background", req.backdrop_badge_background.as_str()),
         ("episode_badge_background", req.episode_badge_background.as_str()),
+        ("csm_enabled", csm_enabled_str),
+        ("csm_position", req.csm_position.as_str()),
+        ("csm_size", req.csm_size.as_str()),
     ];
     let free_key_str;
     if state.config.free_key_enabled.is_none() {

--- a/api/src/handlers/api_keys.rs
+++ b/api/src/handlers/api_keys.rs
@@ -135,6 +135,9 @@ pub struct RenderSettingsResponse {
     pub logo_badge_background: BadgeBackground,
     pub backdrop_badge_background: BadgeBackground,
     pub episode_badge_background: BadgeBackground,
+    pub csm_enabled: bool,
+    pub csm_position: BadgePosition,
+    pub csm_size: BadgeSize,
 }
 
 pub async fn get_settings(
@@ -192,6 +195,9 @@ fn settings_to_response(settings: &db::RenderSettings, fanart_available: bool) -
         logo_badge_background: settings.logo_badge_background,
         backdrop_badge_background: settings.backdrop_badge_background,
         episode_badge_background: settings.episode_badge_background,
+        csm_enabled: settings.csm_enabled,
+        csm_position: settings.csm_position,
+        csm_size: settings.csm_size,
     }
 }
 
@@ -277,6 +283,12 @@ pub struct UpdateSettingsRequest {
     pub backdrop_badge_background: BadgeBackground,
     #[serde(default = "db::default_badge_background")]
     pub episode_badge_background: BadgeBackground,
+    #[serde(default)]
+    pub csm_enabled: bool,
+    #[serde(default = "db::default_csm_position")]
+    pub csm_position: BadgePosition,
+    #[serde(default = "db::default_csm_size")]
+    pub csm_size: BadgeSize,
 }
 
 fn build_upsert(id: i32, req: &UpdateSettingsRequest) -> db::UpsertApiKeySettings<'_> {
@@ -322,6 +334,9 @@ fn build_upsert(id: i32, req: &UpdateSettingsRequest) -> db::UpsertApiKeySetting
         episode_badge_background: req.episode_badge_background.as_str(),
         backdrop_edge_inset_x: db::clamp_edge_inset(req.backdrop_edge_inset_x),
         backdrop_edge_inset_y: db::clamp_edge_inset(req.backdrop_edge_inset_y),
+        csm_enabled: req.csm_enabled,
+        csm_position: req.csm_position.as_str(),
+        csm_size: req.csm_size.as_str(),
     }
 }
 

--- a/api/src/handlers/image.rs
+++ b/api/src/handlers/image.rs
@@ -128,6 +128,18 @@ pub struct ImageQuery {
     #[serde(default)]
     #[param(value_type = Option<i32>)]
     pub edge_inset_y: Option<i32>,
+    /// Override the CSM badge toggle for this request (poster only).
+    #[serde(default)]
+    #[param(value_type = Option<bool>)]
+    pub csm_enabled: Option<bool>,
+    /// Override the CSM badge corner position for this request (poster only): `bc`, `tc`, `tl`, `tr`, `bl`, `br`.
+    #[serde(default)]
+    #[param(value_type = Option<String>)]
+    pub csm_position: Option<BadgePosition>,
+    /// Override the CSM badge size for this request (poster only): `xs`, `s`, `m`, `l`, `xl`.
+    #[serde(default)]
+    #[param(value_type = Option<String>)]
+    pub csm_size: Option<BadgeSize>,
 }
 
 impl ImageQuery {
@@ -150,6 +162,9 @@ impl ImageQuery {
             || self.fit.is_some()
             || self.edge_inset_x.is_some()
             || self.edge_inset_y.is_some()
+            || self.csm_enabled.is_some()
+            || self.csm_position.is_some()
+            || self.csm_size.is_some()
     }
 }
 
@@ -458,6 +473,15 @@ fn apply_query_overrides(
         }
         if let Some(fit) = query.fit {
             s.poster_fit = fit;
+        }
+        if let Some(enabled) = query.csm_enabled {
+            s.csm_enabled = enabled;
+        }
+        if let Some(pos) = query.csm_position {
+            s.csm_position = pos;
+        }
+        if let Some(size) = query.csm_size {
+            s.csm_size = size;
         }
     }
     if kind == cache::ImageType::Backdrop {
@@ -900,6 +924,9 @@ mod tests {
             fit: None,
             edge_inset_x: None,
             edge_inset_y: None,
+            csm_enabled: None,
+            csm_position: None,
+            csm_size: None,
         }
     }
 

--- a/api/src/handlers/preview.rs
+++ b/api/src/handlers/preview.rs
@@ -10,9 +10,9 @@ use crate::error::AppError;
 use crate::handlers::image::ImageQuery;
 use crate::image::generate;
 use crate::image::serve;
-use crate::services::db::{self, BadgeAppearance, BadgeDirection, BadgeStyle, BadgePosition, RenderSettings};
+use crate::services::db::{self, BadgeAppearance, BadgeDirection, BadgeSize, BadgeStyle, BadgePosition, RenderSettings};
 #[cfg(test)]
-use crate::services::db::{BadgeSize, LabelStyle};
+use crate::services::db::LabelStyle;
 use crate::services::ratings::{self, RatingBadge, RatingSource};
 use crate::AppState;
 
@@ -201,10 +201,16 @@ pub async fn preview_poster(
     let badge_appearance = preview_badge_appearance(&query);
     let split = query.split.unwrap_or(false);
     let poster_fit = query.fit.unwrap_or_else(db::default_poster_fit);
+    let csm_enabled = query.csm_enabled.unwrap_or(false);
+    let csm_position = query.csm_position.unwrap_or_else(db::default_csm_position);
+    let csm_size = query.csm_size.unwrap_or_else(db::default_csm_size);
     let ratings_suffix = ratings::ratings_cache_suffix(ratings_order, ratings_exclude, ratings_limit);
     let mut preview_settings = preview_render_settings(cache::ImageType::Poster, badge_style, label_style, badge_size, position, badge_direction, badge_appearance, ratings_limit, ratings_order, ratings_exclude);
     preview_settings.poster_badge_split = split;
     preview_settings.poster_fit = poster_fit;
+    preview_settings.csm_enabled = csm_enabled;
+    preview_settings.csm_position = csm_position;
+    preview_settings.csm_size = csm_size;
     let suffix = serve::settings_cache_suffix_with_ratings(&preview_settings, cache::ImageType::Poster, image_size, &ratings_suffix);
     let cache_key = format!("preview:{suffix}");
     let cache_path = cache::preview_path(&state.config.cache_dir, cache::ImageType::Poster, &suffix, "jpg")?;
@@ -225,11 +231,15 @@ pub async fn preview_poster(
     let badges = sample_badges();
     let badges = ratings::apply_rating_preferences(badges, ratings_order, ratings_exclude, ratings_limit);
 
+    // In the preview we always show a demo CSM pill ("12+") when CSM is enabled
+    // so the user can see exactly where and how large the badge will appear.
+    let csm_age_label: Option<String> = if csm_enabled { Some("12+".to_string()) } else { None };
+
     let poster_png: &'static Vec<u8> = &SAMPLE_POSTER_PNG;
     let font = state.font.clone();
     let quality = state.config.image_quality;
     let buf = tokio::task::spawn_blocking(move || {
-        generate::render_poster_sync(poster_png, &badges, &font, quality, position, badge_style, label_style, badge_appearance, badge_direction, target_width, badge_scale, badge_size, split, poster_fit)
+        generate::render_poster_sync(poster_png, &badges, &font, quality, position, badge_style, label_style, badge_appearance, badge_direction, target_width, badge_scale, badge_size, split, poster_fit, csm_enabled, csm_age_label.as_deref(), csm_position, csm_size)
     })
     .await
     .map_err(|e| AppError::Other(e.to_string()))??;
@@ -495,7 +505,7 @@ mod tests {
     fn sample_poster_renders_with_badges() {
         let font = ab_glyph::FontArc::try_from_slice(crate::FONT_BYTES).unwrap();
         let badges = sample_badges();
-        let result = generate::render_poster_sync(&SAMPLE_POSTER_PNG, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, db::PosterFit::Native);
+        let result = generate::render_poster_sync(&SAMPLE_POSTER_PNG, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, db::PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium);
         let buf = result.expect("rendering should succeed");
         // Valid JPEG
         assert_eq!(buf[0], 0xFF);
@@ -506,7 +516,7 @@ mod tests {
     #[test]
     fn sample_poster_renders_with_no_badges() {
         let font = ab_glyph::FontArc::try_from_slice(crate::FONT_BYTES).unwrap();
-        let result = generate::render_poster_sync(&SAMPLE_POSTER_PNG, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, db::PosterFit::Native);
+        let result = generate::render_poster_sync(&SAMPLE_POSTER_PNG, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, db::PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium);
         let buf = result.expect("rendering should succeed");
         assert_eq!(buf[0], 0xFF);
         assert_eq!(buf[1], 0xD8);

--- a/api/src/image/badge.rs
+++ b/api/src/image/badge.rs
@@ -786,7 +786,113 @@ mod tests {
     }
 }
 
-/// Round the four outer corners of the full image to radius `r` by clearing
+// --- CSM age-rating pill ---
+
+/// Base dimensions for the CSM age-rating pill at 1× scale.
+const BASE_CSM_PILL_HEIGHT: u32 = 58;
+const BASE_CSM_PILL_PADDING_H: u32 = 20;
+/// Dark semi-transparent background — 65% opacity (0.65 × 255 ≈ 166).
+const CSM_PILL_BG: Rgba<u8> = Rgba([0, 0, 0, 166]);
+
+/// Render a CSM age-rating pill badge: a dark semi-transparent rounded pill
+/// with white bold text (e.g. "12+"). Width scales to the text length;
+/// height is fixed at `BASE_CSM_PILL_HEIGHT * badge_scale`.
+///
+/// Returns `None` when `label` is empty.
+pub fn draw_csm_pill(label: &str, font: &FontArc, badge_scale: f32) -> Option<RgbaImage> {
+    if label.is_empty() {
+        return None;
+    }
+
+    let pill_h = (BASE_CSM_PILL_HEIGHT as f32 * badge_scale).round() as u32;
+    let padding_h = (BASE_CSM_PILL_PADDING_H as f32 * badge_scale).round() as u32;
+    let font_size = BASE_FONT_SIZE * badge_scale;
+    let scale = PxScale::from(font_size);
+    let scaled_font = font.as_scaled(scale);
+
+    let text_w = text_width(label, &scaled_font);
+    let pill_w = text_w + padding_h * 2;
+
+    let mut img = RgbaImage::new(pill_w, pill_h);
+
+    // Fill the pill background.
+    draw_filled_rect_mut(&mut img, Rect::at(0, 0).of_size(pill_w, pill_h), CSM_PILL_BG);
+    // Fully rounded caps (radius = half the height → stadium / pill shape).
+    round_corners(&mut img, pill_h / 2);
+
+    // Centre the text vertically and horizontally.
+    let text_x = ((pill_w.saturating_sub(text_w)) / 2) as i32;
+    let text_y = (pill_h as i32 - font_size as i32) / 2;
+    draw_text_mut(&mut img, Rgba([255, 255, 255, 255]), text_x, text_y, scale, font, label);
+
+    Some(img)
+}
+
+#[cfg(test)]
+mod csm_tests {
+    use super::*;
+
+    fn test_font() -> FontArc {
+        FontArc::try_from_slice(crate::FONT_BYTES).unwrap()
+    }
+
+    #[test]
+    fn draw_csm_pill_basic() {
+        let font = test_font();
+        let img = draw_csm_pill("12+", &font, 1.0).expect("should produce image");
+        assert_eq!(img.height(), BASE_CSM_PILL_HEIGHT);
+        assert!(img.width() > 0);
+    }
+
+    #[test]
+    fn draw_csm_pill_empty_returns_none() {
+        let font = test_font();
+        assert!(draw_csm_pill("", &font, 1.0).is_none());
+    }
+
+    #[test]
+    fn draw_csm_pill_wider_text_produces_wider_pill() {
+        let font = test_font();
+        let short = draw_csm_pill("7+", &font, 1.0).unwrap();
+        let long = draw_csm_pill("18+", &font, 1.0).unwrap();
+        assert!(long.width() > short.width());
+    }
+
+    #[test]
+    fn draw_csm_pill_scaled_2x_doubles_height() {
+        let font = test_font();
+        let img = draw_csm_pill("12+", &font, 2.0).unwrap();
+        assert_eq!(img.height(), BASE_CSM_PILL_HEIGHT * 2);
+    }
+
+    #[test]
+    fn draw_csm_pill_has_correct_opacity() {
+        // Sample a pixel in the centre of the pill — it should be the dark
+        // semi-transparent background (alpha ≈ 166, never fully opaque).
+        let font = test_font();
+        let img = draw_csm_pill("12+", &font, 1.0).unwrap();
+        let cx = img.width() / 2;
+        let cy = img.height() / 2;
+        // The centre pixel may be over text (white) — check the left edge padding
+        // area which is definitely background.
+        let bg_px = img.get_pixel(4, cy);
+        assert!(bg_px[3] > 0, "background should be visible");
+        assert!(bg_px[3] <= 200, "background should not be fully opaque");
+    }
+
+    #[test]
+    fn draw_csm_pill_corners_are_transparent() {
+        let font = test_font();
+        let img = draw_csm_pill("12+", &font, 1.0).unwrap();
+        // Corners should be cleared by round_corners.
+        assert_eq!(img.get_pixel(0, 0)[3], 0, "top-left corner should be transparent");
+        assert_eq!(img.get_pixel(img.width() - 1, 0)[3], 0, "top-right corner should be transparent");
+        assert_eq!(img.get_pixel(0, img.height() - 1)[3], 0, "bottom-left corner should be transparent");
+        assert_eq!(img.get_pixel(img.width() - 1, img.height() - 1)[3], 0, "bottom-right corner should be transparent");
+    }
+}
+
+
 /// pixels outside each corner arc to transparent. `r` is clamped so the arcs
 /// never overlap, so passing `r` = half the short axis yields a pill / stadium
 /// shape. The badge image spans exactly one badge, so its corners are the

--- a/api/src/image/generate.rs
+++ b/api/src/image/generate.rs
@@ -55,6 +55,15 @@ pub struct ImageParams<'a> {
     pub badge_size: BadgeSize,
     /// When true, skip writing base poster images to disk (CDN handles caching).
     pub external_cache_only: bool,
+    /// Whether to overlay a CSM age-rating badge on the poster.
+    pub csm_enabled: bool,
+    /// Age rating string sourced from MDBList (e.g. "12+"). `None` means no
+    /// CSM data is available — the badge is skipped even if `csm_enabled` is true.
+    pub csm_age: Option<String>,
+    /// Corner of the poster where the CSM badge is anchored.
+    pub csm_position: BadgePosition,
+    /// Size of the CSM badge (controls `badge_scale` passed to `draw_csm_pill`).
+    pub csm_size: BadgeSize,
 }
 
 pub async fn generate_poster(params: ImageParams<'_>) -> Result<Vec<u8>, AppError> {
@@ -80,6 +89,10 @@ pub async fn generate_poster(params: ImageParams<'_>) -> Result<Vec<u8>, AppErro
         badge_size,
         tmdb_size,
         external_cache_only,
+        csm_enabled,
+        csm_age,
+        csm_position,
+        csm_size,
     } = params;
 
     let poster_bytes = if let Some(bytes) = poster_bytes_override {
@@ -132,7 +145,7 @@ pub async fn generate_poster(params: ImageParams<'_>) -> Result<Vec<u8>, AppErro
     let badges = badges.to_vec();
     let font = font.clone();
     let buf = tokio::task::spawn_blocking(move || {
-        render_poster_sync(&poster_bytes, &badges, &font, quality, poster_position, badge_style, label_style, badge_appearance, badge_direction, target_width, badge_scale, badge_size, poster_badge_split, poster_fit)
+        render_poster_sync(&poster_bytes, &badges, &font, quality, poster_position, badge_style, label_style, badge_appearance, badge_direction, target_width, badge_scale, badge_size, poster_badge_split, poster_fit, csm_enabled, csm_age.as_deref(), csm_position, csm_size)
     })
     .await
     .map_err(|e| AppError::Other(e.to_string()))??;
@@ -337,6 +350,53 @@ fn fit_poster(base: DynamicImage, target_width: u32, fit: PosterFit) -> RgbaImag
     }
 }
 
+/// Overlay a CSM age-rating pill badge onto the canvas at the given corner.
+///
+/// When the CSM badge shares the same corner as the rating badges, it is placed
+/// *below* (or after) them so both groups remain visible. This is handled by
+/// using the badge group's total height as an extra vertical offset.
+fn overlay_csm_badge(
+    canvas: &mut RgbaImage,
+    label: &str,
+    font: &FontArc,
+    csm_position: BadgePosition,
+    csm_scale: f32,
+    rating_group_offset_y: u32,
+) {
+    let Some(pill) = badge::draw_csm_pill(label, font, csm_scale) else {
+        return;
+    };
+
+    let top_margin = (BADGE_TOP_MARGIN as f32 * csm_scale).round() as u32;
+    let bottom_margin = (BADGE_BOTTOM_MARGIN as f32 * csm_scale).round() as u32;
+    let side_margin = (BADGE_SIDE_MARGIN as f32 * csm_scale).round() as u32;
+    let spacing = (BADGE_VERT_SPACING as f32 * csm_scale).round() as u32;
+
+    let pw = pill.width();
+    let ph = pill.height();
+
+    // Horizontal placement
+    let x = if csm_position.is_left() {
+        side_margin
+    } else if csm_position.is_right() {
+        canvas.width().saturating_sub(pw + side_margin)
+    } else {
+        canvas.width().saturating_sub(pw) / 2
+    } as i64;
+
+    // Vertical placement — offset below/above the rating group when same corner
+    let y = if csm_position.is_top() {
+        (top_margin + rating_group_offset_y + if rating_group_offset_y > 0 { spacing } else { 0 }) as i64
+    } else if csm_position.is_bottom() {
+        canvas.height().saturating_sub(ph + bottom_margin + rating_group_offset_y + if rating_group_offset_y > 0 { spacing } else { 0 }) as i64
+    } else {
+        // Left/Right centered: place below vertical center of canvas
+        (canvas.height().saturating_sub(ph)) as i64 / 2 + rating_group_offset_y as i64
+    };
+
+    imageops::overlay(canvas, &pill, x, y);
+}
+
 pub fn render_poster_sync(
     poster_bytes: &[u8],
     badges: &[RatingBadge],
@@ -352,6 +412,10 @@ pub fn render_poster_sync(
     badge_size: BadgeSize,
     poster_badge_split: bool,
     poster_fit: PosterFit,
+    csm_enabled: bool,
+    csm_age: Option<&str>,
+    csm_position: BadgePosition,
+    csm_size: BadgeSize,
 ) -> Result<Vec<u8>, AppError> {
     // A pill is a horizontal lozenge (icon/label left, value right) — never a
     // vertical stacked badge, even when the configured style is vertical.
@@ -390,6 +454,50 @@ pub fn render_poster_sync(
             overlay_poster_group(&mut canvas, second, opposite, badge_direction, max_per_row, badge_scale);
         } else {
             overlay_poster_group(&mut canvas, &badge_images, poster_position, badge_direction, max_per_row, badge_scale);
+        }
+    }
+
+    // CSM age-rating pill overlay (poster only).
+    // When the CSM badge shares the same corner as the rating badges, compute
+    // how tall the rating group is so the pill is placed clear of it.
+    if csm_enabled {
+        if let Some(label) = csm_age {
+            let csm_scale = csm_size.scale_factor();
+            // Estimate the height of the rating group at the CSM corner so we
+            // can push the pill below/above it. Only applies when the two groups
+            // share the same anchor corner and badges are present.
+            let rating_offset = if !badges.is_empty() && csm_position == poster_position {
+                // Use the first badge's height as an approximation. If the
+                // group rendered with split, one half moved to the opposite
+                // corner so the shared-corner half is roughly half the badges.
+                let sample_badge_h = {
+                    let badge_style = badge_style.for_shape(badge_appearance.shape);
+                    if badge_style.is_vertical() {
+                        badge::render_vertical_badge(&badges[0], font, label_style, badge_appearance, badge_scale).height()
+                    } else {
+                        badge::render_badges_uniform(&badges[..1], font, label_style, badge_appearance, badge_scale)[0].height()
+                    }
+                };
+                let n = if poster_badge_split { badges.len().div_ceil(2) } else { badges.len() };
+                let rows = if badge_direction.is_vertical() {
+                    n as u32
+                } else {
+                    let max_per_row = match badge_size {
+                        BadgeSize::Large | BadgeSize::ExtraLarge => {
+                            if badge_style.for_shape(badge_appearance.shape) == BadgeStyle::Horizontal { 2 } else { 4 }
+                        }
+                        _ => MAX_BADGES_PER_ROW as u32,
+                    };
+                    (n as u32).div_ceil(max_per_row)
+                };
+                let row_sp = (BADGE_ROW_SPACING as f32 * badge_scale).round() as u32;
+                let top_margin = (BADGE_TOP_MARGIN as f32 * badge_scale).round() as u32;
+                let bot_margin = (BADGE_BOTTOM_MARGIN as f32 * badge_scale).round() as u32;
+                top_margin + bot_margin + sample_badge_h * rows + row_sp * rows.saturating_sub(1)
+            } else {
+                0
+            };
+            overlay_csm_badge(&mut canvas, label, font, csm_position, csm_scale, rating_offset);
         }
     }
 
@@ -800,7 +908,7 @@ mod tests {
         )
         .unwrap();
 
-        let result = render_poster_sync(&png_bytes, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert!(!result.is_empty());
         // Should be valid JPEG
         assert_eq!(result[0], 0xFF);
@@ -843,7 +951,7 @@ mod tests {
             },
         ];
 
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert!(!result.is_empty());
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
@@ -852,7 +960,7 @@ mod tests {
     #[test]
     fn render_poster_invalid_image_bytes() {
         let font = FontArc::try_from_slice(crate::FONT_BYTES).unwrap();
-        let result = render_poster_sync(b"not an image", &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native);
+        let result = render_poster_sync(b"not an image", &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium);
         assert!(result.is_err());
     }
 
@@ -1136,7 +1244,7 @@ mod tests {
                 value: "8.5".to_string(),
             },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::TopCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::TopCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1155,7 +1263,7 @@ mod tests {
                 value: "8.5".to_string(),
             },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::Left, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::Left, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1172,7 +1280,7 @@ mod tests {
                 value: "8.5".to_string(),
             },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::Right, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::Right, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1187,7 +1295,7 @@ mod tests {
             RatingBadge { source: RatingSource::Imdb, value: "8.5".to_string() },
             RatingBadge { source: RatingSource::Rt, value: "92%".to_string() },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Icon, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Icon, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1203,17 +1311,17 @@ mod tests {
             RatingBadge { source: RatingSource::Rt, value: "92%".to_string() },
         ];
         // vertical direction at bottom-center
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
 
         // vertical direction at top-left corner
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::TopLeft, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::TopLeft, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
 
         // vertical direction at bottom-right corner
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomRight, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomRight, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1260,7 +1368,7 @@ mod tests {
             RatingBadge { source: RatingSource::Rt, value: "92%".to_string() },
             RatingBadge { source: RatingSource::RtAudience, value: "45%".to_string() },
         ];
-        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Official, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png_bytes, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Official, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1330,6 +1438,10 @@ mod tests {
             tmdb_size: Arc::from("w500"),
             badge_size: BadgeSize::Medium,
             external_cache_only: false,
+            csm_enabled: false,
+            csm_age: None,
+            csm_position: BadgePosition::TopRight,
+            csm_size: BadgeSize::Medium,
         })
         .await;
 
@@ -1368,6 +1480,10 @@ mod tests {
             tmdb_size: Arc::from("w500"),
             badge_size: BadgeSize::Medium,
             external_cache_only: false,
+            csm_enabled: false,
+            csm_age: None,
+            csm_position: BadgePosition::TopRight,
+            csm_size: BadgeSize::Medium,
         })
         .await;
 
@@ -1453,7 +1569,7 @@ mod tests {
         let font = FontArc::try_from_slice(crate::FONT_BYTES).unwrap();
         let png = test_png(500, 750);
         // Render at large size (1280 width, ~2.2x badge scale)
-        let result = render_poster_sync(&png, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 1280, 2.2, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 1280, 2.2, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert!(!result.is_empty());
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
@@ -1471,7 +1587,7 @@ mod tests {
             RatingBadge { source: RatingSource::Imdb, value: "8.5".to_string() },
             RatingBadge { source: RatingSource::Rt, value: "92%".to_string() },
         ];
-        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 1280, 2.2, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 1280, 2.2, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let img = image::load_from_memory(&result).unwrap();
         assert_eq!(img.width(), 1280);
     }
@@ -1487,12 +1603,12 @@ mod tests {
             RatingBadge { source: RatingSource::Tmdb, value: "85%".to_string() },
         ];
         // Large badge size with horizontal style — should use max 2 per row
-        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Large, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Large, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
 
         // Extra-large badge size with vertical style — should use max 4 per row
-        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Vertical, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::ExtraLarge, false, PosterFit::Native).unwrap();
+        let result = render_poster_sync(&png, &badges, &font, 85, BadgePosition::BottomCenter, BadgeStyle::Vertical, LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal, 500, 1.0, BadgeSize::ExtraLarge, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         assert_eq!(result[0], 0xFF);
         assert_eq!(result[1], 0xD8);
     }
@@ -1535,7 +1651,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::TopCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cy < 0.33, "TopCenter: badge y-centroid {cy:.2} should be in top third");
         assert!(cx > 0.3 && cx < 0.7, "TopCenter: badge x-centroid {cx:.2} should be centered");
@@ -1547,7 +1663,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cy > 0.67, "BottomCenter: badge y-centroid {cy:.2} should be in bottom third");
         assert!(cx > 0.3 && cx < 0.7, "BottomCenter: badge x-centroid {cx:.2} should be centered");
@@ -1559,7 +1675,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::Left, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cx < 0.5, "Left: badge x-centroid {cx:.2} should be in left half");
         assert!(cy > 0.25 && cy < 0.75, "Left: badge y-centroid {cy:.2} should be vertically centered");
@@ -1571,7 +1687,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::Right, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cx > 0.5, "Right: badge x-centroid {cx:.2} should be in right half");
         assert!(cy > 0.25 && cy < 0.75, "Right: badge y-centroid {cy:.2} should be vertically centered");
@@ -1583,7 +1699,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::TopLeft, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cx < 0.5, "TopLeft: badge x-centroid {cx:.2} should be in left half");
         assert!(cy < 0.5, "TopLeft: badge y-centroid {cy:.2} should be in top half");
@@ -1595,7 +1711,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &position_test_badges(), &font, 85,
             BadgePosition::BottomRight, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (cx, cy) = badge_centroid(&result);
         assert!(cx > 0.5, "BottomRight: badge x-centroid {cx:.2} should be in right half");
         assert!(cy > 0.5, "BottomRight: badge y-centroid {cy:.2} should be in bottom half");
@@ -1636,7 +1752,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &split_test_badges(), &font, 85,
             BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, true, PosterFit::Native).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, true, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (top, bottom, _l, _r) = badge_pixel_halves(&result);
         assert!(top > 0, "split: expected badge pixels in the top half, got {top}");
         assert!(bottom > 0, "split: expected badge pixels in the bottom half, got {bottom}");
@@ -1645,7 +1761,7 @@ mod tests {
         let unsplit = render_poster_sync(&test_png(500, 750), &split_test_badges(), &font, 85,
             BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, false, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (top_u, _b, _l, _r) = badge_pixel_halves(&unsplit);
         assert_eq!(top_u, 0, "no-split: expected no badge pixels in the top half, got {top_u}");
     }
@@ -1657,7 +1773,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &split_test_badges(), &font, 85,
             BadgePosition::Left, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, true, PosterFit::Native).unwrap();
+            BadgeDirection::Vertical, 500, 1.0, BadgeSize::Medium, true, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (_t, _b, left, right) = badge_pixel_halves(&result);
         assert!(left > 0, "split: expected badge pixels in the left half, got {left}");
         assert!(right > 0, "split: expected badge pixels in the right half, got {right}");
@@ -1674,7 +1790,7 @@ mod tests {
         let result = render_poster_sync(&test_png(500, 750), &badges, &font, 85,
             BadgePosition::BottomCenter, BadgeStyle::Horizontal, LabelStyle::Text,
             BadgeAppearance::default(),
-            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, true, PosterFit::Native).unwrap();
+            BadgeDirection::Horizontal, 500, 1.0, BadgeSize::Medium, true, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium).unwrap();
         let (top, bottom, _l, _r) = badge_pixel_halves(&result);
         assert_eq!(top, 0, "single badge: nothing should move to the top half, got {top}");
         assert!(bottom > 0, "single badge: badge should remain in the bottom half, got {bottom}");
@@ -1692,6 +1808,7 @@ mod tests {
             src, &[], &font, 85, BadgePosition::BottomCenter, BadgeStyle::Horizontal,
             LabelStyle::Text, BadgeAppearance::default(), BadgeDirection::Horizontal,
             target_width, 1.0, BadgeSize::Medium, false, fit,
+            false, None, BadgePosition::TopRight, BadgeSize::Medium,
         )
         .unwrap()
     }
@@ -1718,9 +1835,9 @@ mod tests {
     #[test]
     fn poster_fit_native_preserves_source_ratio() {
         // Native keeps the legacy behavior: scale to width, keep the source ratio.
-        let square = render_with_fit(&test_png(600, 600), 580, PosterFit::Native);
+        let square = render_with_fit(&test_png(600, 600), 580, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium);
         assert_eq!(rendered_dims(&square), (580, 580), "native keeps a 1:1 source 1:1");
-        let wide = render_with_fit(&test_png(900, 600), 580, PosterFit::Native);
+        let wide = render_with_fit(&test_png(900, 600), 580, PosterFit::Native, false, None, BadgePosition::TopRight, BadgeSize::Medium);
         // round(600 * 580 / 900) = 387
         assert_eq!(rendered_dims(&wide), (580, 387), "native keeps a 3:2 source ratio");
     }

--- a/api/src/image/serve.rs
+++ b/api/src/image/serve.rs
@@ -234,6 +234,9 @@ pub fn settings_cache_suffix_with_ratings(
         logo_badge_background: _,
         backdrop_badge_background: _,
         episode_badge_background: _,
+        csm_enabled: _,
+        csm_position: _,
+        csm_size: _,
     } = settings;
 
     let resolved_size = resolve_image_size(image_size);
@@ -258,10 +261,18 @@ pub fn settings_cache_suffix_with_ratings(
             // pre-feature poster cache keys — all native — stay valid and the
             // default reuses them. Opting into cover/pad/blur emits a token.
             let fit = settings.poster_fit.cache_suffix();
+            // CSM badge — only tokenized when enabled (default off keeps existing
+            // cache keys unchanged). Position and size are included so changing
+            // them busts the cache correctly.
+            let csm = if settings.csm_enabled {
+                format!(".csm{}{}", settings.csm_position.as_str(), settings.csm_size.cache_suffix())
+            } else {
+                String::new()
+            };
             // Shape/background sit immediately after badge size (before the
             // optional split token) so the v003 cache-key migration can insert
             // their defaults with a single uniform rule across all image types.
-            format!("{rs}{ps}{bs}{ls}{bd}{bsz}{shp}{bgd}{split}{fit}{is_suffix}")
+            format!("{rs}{ps}{bs}{ls}{bd}{bsz}{shp}{bgd}{split}{fit}{csm}{is_suffix}")
         }
         cache::ImageType::Logo => {
             let bs = badge_style_cache_suffix(settings.logo_badge_style.for_shape(settings.logo_badge_shape).as_str());
@@ -494,6 +505,9 @@ struct CrossIdInfo {
     media_type: MediaType,
     release_date: Option<String>,
     episode: Option<id::EpisodeInfo>,
+    /// CSM age rating string sourced from MDBList (e.g. "12+"), passed through
+    /// to `ImageParams` for conditional overlay on the rendered poster.
+    csm_age: Option<String>,
 }
 
 impl CrossIdInfo {
@@ -506,6 +520,7 @@ impl CrossIdInfo {
             media_type: resolved.media_type,
             release_date: resolved.release_date.clone(),
             episode: resolved.episode.clone(),
+            csm_age: ratings.csm_age.clone(),
         }
     }
 }
@@ -1408,6 +1423,10 @@ async fn generate_poster_with_source(
         badge_size: settings.poster_badge_size,
         tmdb_size,
         external_cache_only: state.config.external_cache_only,
+        csm_enabled: settings.csm_enabled,
+        csm_age: cross_ids.csm_age.clone(),
+        csm_position: settings.csm_position,
+        csm_size: settings.csm_size,
     })
     .await?;
 

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -45,6 +45,12 @@ async fn main() {
         ))
         .timeout(Duration::from_secs(30))
         .connect_timeout(Duration::from_secs(10))
+        // TMDB (and other providers) return gzip-compressed responses; without
+        // explicit decompression support reqwest passes the raw bytes through
+        // and JSON parsing fails with "unexpected byte 0x1f" (gzip magic number).
+        .gzip(true)
+        .brotli(true)
+        .deflate(true)
         .build()
         .expect("failed to build HTTP client");
     let font = FontArc::try_from_slice(FONT_BYTES).expect("failed to load font");

--- a/api/src/services/db.rs
+++ b/api/src/services/db.rs
@@ -680,6 +680,14 @@ pub fn default_badge_size() -> BadgeSize {
     BadgeSize::Medium
 }
 
+pub fn default_csm_position() -> BadgePosition {
+    BadgePosition::TopRight
+}
+
+pub fn default_csm_size() -> BadgeSize {
+    BadgeSize::Medium
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BadgeSize {
     ExtraSmall,
@@ -715,11 +723,11 @@ impl BadgeSize {
 
     pub fn scale_factor(self) -> f32 {
         match self {
-            Self::ExtraSmall => 0.5,
-            Self::Small => 0.75,
-            Self::Medium => 1.0,
-            Self::Large => 1.25,
-            Self::ExtraLarge => 1.5,
+            Self::ExtraSmall => 0.75,
+            Self::Small => 1.0,
+            Self::Medium => 1.5,
+            Self::Large => 1.75,
+            Self::ExtraLarge => 2.25,
         }
     }
 
@@ -2131,6 +2139,9 @@ pub struct UpsertApiKeySettings<'a> {
     pub episode_badge_background: &'a str,
     pub backdrop_edge_inset_x: i32,
     pub backdrop_edge_inset_y: i32,
+    pub csm_enabled: bool,
+    pub csm_position: &'a str,
+    pub csm_size: &'a str,
 }
 
 pub async fn upsert_api_key_settings(
@@ -2179,6 +2190,9 @@ pub async fn upsert_api_key_settings(
         episode_badge_background: Set(params.episode_badge_background.to_string()),
         backdrop_edge_inset_x: Set(params.backdrop_edge_inset_x),
         backdrop_edge_inset_y: Set(params.backdrop_edge_inset_y),
+        csm_enabled: Set(params.csm_enabled),
+        csm_position: Set(params.csm_position.to_string()),
+        csm_size: Set(params.csm_size.to_string()),
     };
     api_key_settings::Entity::insert(model)
         .on_conflict(
@@ -2224,6 +2238,9 @@ pub async fn upsert_api_key_settings(
                     api_key_settings::Column::EpisodeBadgeBackground,
                     api_key_settings::Column::BackdropEdgeInsetX,
                     api_key_settings::Column::BackdropEdgeInsetY,
+                    api_key_settings::Column::CsmEnabled,
+                    api_key_settings::Column::CsmPosition,
+                    api_key_settings::Column::CsmSize,
                 ])
                 .to_owned(),
         )
@@ -2296,6 +2313,12 @@ pub struct RenderSettings {
     pub logo_badge_background: BadgeBackground,
     pub backdrop_badge_background: BadgeBackground,
     pub episode_badge_background: BadgeBackground,
+    /// Whether to overlay a CSM age-rating badge on posters.
+    pub csm_enabled: bool,
+    /// Corner of the poster where the CSM badge is anchored.
+    pub csm_position: BadgePosition,
+    /// Size of the CSM badge.
+    pub csm_size: BadgeSize,
 }
 
 impl RenderSettings {
@@ -2361,6 +2384,9 @@ impl Default for RenderSettings {
             logo_badge_background: default_badge_background(),
             backdrop_badge_background: default_badge_background(),
             episode_badge_background: default_badge_background(),
+            csm_enabled: false,
+            csm_position: default_csm_position(),
+            csm_size: default_csm_size(),
         }
     }
 }
@@ -2449,6 +2475,12 @@ pub fn parse_global_render_settings(globals: &HashMap<String, String>) -> Render
         logo_badge_background: global_or(globals, "logo_badge_background", BadgeBackground::parse, defaults.logo_badge_background),
         backdrop_badge_background: global_or(globals, "backdrop_badge_background", BadgeBackground::parse, defaults.backdrop_badge_background),
         episode_badge_background: global_or(globals, "episode_badge_background", BadgeBackground::parse, defaults.episode_badge_background),
+        csm_enabled: globals
+            .get("csm_enabled")
+            .map(|v| v == "true")
+            .unwrap_or(defaults.csm_enabled),
+        csm_position: global_or(globals, "csm_position", BadgePosition::parse, defaults.csm_position),
+        csm_size: global_or(globals, "csm_size", BadgeSize::parse, defaults.csm_size),
     }
 }
 
@@ -2502,6 +2534,9 @@ pub async fn get_effective_render_settings(
                 logo_badge_background: parse_setting_or_default(&s.logo_badge_background, "logo_badge_background", BadgeBackground::parse, default_badge_background()),
                 backdrop_badge_background: parse_setting_or_default(&s.backdrop_badge_background, "backdrop_badge_background", BadgeBackground::parse, default_badge_background()),
                 episode_badge_background: parse_setting_or_default(&s.episode_badge_background, "episode_badge_background", BadgeBackground::parse, default_badge_background()),
+                csm_enabled: s.csm_enabled,
+                csm_position: parse_setting_or_default(&s.csm_position, "csm_position", BadgePosition::parse, default_csm_position()),
+                csm_size: parse_setting_or_default(&s.csm_size, "csm_size", BadgeSize::parse, default_csm_size()),
             };
         }
         Ok(None) => {} // no per-key override, fall through

--- a/api/src/services/fanart.rs
+++ b/api/src/services/fanart.rs
@@ -13,10 +13,27 @@ pub struct FanartClient {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct FanartPoster {
+    #[serde(default)]
     pub id: String,
+    #[serde(default)]
     pub url: String,
+    #[serde(default)]
     pub lang: String,
+    #[serde(default)]
     pub likes: String,
+}
+
+/// Deserialize a `Vec<FanartPoster>`, skipping individual entries that fail
+/// to parse rather than failing the whole array.
+fn deserialize_lenient_posters<'de, D>(deserializer: D) -> Result<Vec<FanartPoster>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: Vec<serde_json::Value> = Vec::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|v| serde_json::from_value(v).ok())
+        .collect())
 }
 
 /// All image types fetched from fanart.tv in a single API call.
@@ -29,21 +46,21 @@ pub struct FanartImages {
 
 #[derive(Debug, Deserialize)]
 struct MovieImages {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_posters")]
     movieposter: Vec<FanartPoster>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_posters")]
     hdmovielogo: Vec<FanartPoster>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_posters")]
     moviebackground: Vec<FanartPoster>,
 }
 
 #[derive(Debug, Deserialize)]
 struct TvImages {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_posters")]
     tvposter: Vec<FanartPoster>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_posters")]
     hdtvlogo: Vec<FanartPoster>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_posters")]
     showbackground: Vec<FanartPoster>,
 }
 

--- a/api/src/services/mdblist.rs
+++ b/api/src/services/mdblist.rs
@@ -14,13 +14,57 @@ pub struct MdblistClient {
 
 #[derive(Debug, Deserialize)]
 pub struct MdblistResponse {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_ratings")]
     pub ratings: Vec<MdblistRating>,
     #[serde(default)]
     pub ids: MdblistIds,
     /// MDBList's own aggregated 0–100 score (rendered as the `mdblist` source).
     #[serde(default)]
     pub score: Option<f64>,
+    /// Age rating string (e.g. "12", "PG-13"). May be a JSON string or number.
+    #[serde(default)]
+    pub age_rating: Option<serde_json::Value>,
+}
+
+impl MdblistResponse {
+    /// Extract a CSM age rating string from the `age_rating` field, formatted
+    /// as "N+" (e.g. "12+"). Returns `None` if the field is absent, null, or
+    /// zero/empty. Does not gate on a `commonsense` boolean — the age_rating
+    /// field is used directly.
+    pub fn csm_age(&self) -> Option<String> {
+        match &self.age_rating {
+            Some(serde_json::Value::String(s)) => {
+                let s = s.trim();
+                if s.is_empty() || s == "0" {
+                    None
+                } else {
+                    Some(format!("{s}+"))
+                }
+            }
+            Some(serde_json::Value::Number(n)) => {
+                let v = n.as_f64().unwrap_or(0.0);
+                if v <= 0.0 {
+                    None
+                } else {
+                    Some(format!("{:.0}+", v))
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+/// Deserialize a `Vec<MdblistRating>`, skipping individual entries that fail
+/// to parse rather than failing the whole array.
+fn deserialize_lenient_ratings<'de, D>(deserializer: D) -> Result<Vec<MdblistRating>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let raw: Vec<serde_json::Value> = Vec::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|v| serde_json::from_value(v).ok())
+        .collect())
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -32,9 +76,13 @@ pub struct MdblistIds {
 
 #[derive(Debug, Deserialize)]
 pub struct MdblistRating {
+    #[serde(default)]
     pub source: String,
+    #[serde(default)]
     pub value: Option<f64>,
+    #[serde(default)]
     pub score: Option<f64>,
+    #[serde(default)]
     pub votes: Option<i64>,
 }
 
@@ -130,5 +178,70 @@ mod tests {
         // The TMDB fallback endpoint that restores ratings for IMDb-less titles.
         assert_eq!(tmdb_ratings_url("show", 1429), "https://api.mdblist.com/tmdb/show/1429");
         assert_eq!(tmdb_ratings_url("movie", 550), "https://api.mdblist.com/tmdb/movie/550");
+    }
+
+    #[test]
+    fn csm_age_string_formats_with_plus() {
+        let resp: MdblistResponse = serde_json::from_str(r#"{"age_rating": "12"}"#).unwrap();
+        assert_eq!(resp.csm_age(), Some("12+".to_string()));
+    }
+
+    #[test]
+    fn csm_age_numeric_formats_with_plus() {
+        let resp: MdblistResponse = serde_json::from_str(r#"{"age_rating": 7}"#).unwrap();
+        assert_eq!(resp.csm_age(), Some("7+".to_string()));
+    }
+
+    #[test]
+    fn csm_age_zero_string_returns_none() {
+        let resp: MdblistResponse = serde_json::from_str(r#"{"age_rating": "0"}"#).unwrap();
+        assert_eq!(resp.csm_age(), None);
+    }
+
+    #[test]
+    fn csm_age_zero_number_returns_none() {
+        let resp: MdblistResponse = serde_json::from_str(r#"{"age_rating": 0}"#).unwrap();
+        assert_eq!(resp.csm_age(), None);
+    }
+
+    #[test]
+    fn csm_age_null_returns_none() {
+        let resp: MdblistResponse = serde_json::from_str(r#"{"age_rating": null}"#).unwrap();
+        assert_eq!(resp.csm_age(), None);
+    }
+
+    #[test]
+    fn csm_age_absent_returns_none() {
+        let resp: MdblistResponse = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(resp.csm_age(), None);
+    }
+
+    #[test]
+    fn csm_age_empty_string_returns_none() {
+        let resp: MdblistResponse = serde_json::from_str(r#"{"age_rating": ""}"#).unwrap();
+        assert_eq!(resp.csm_age(), None);
+    }
+
+    #[test]
+    fn csm_age_pg13_string_preserved() {
+        let resp: MdblistResponse = serde_json::from_str(r#"{"age_rating": "PG-13"}"#).unwrap();
+        assert_eq!(resp.csm_age(), Some("PG-13+".to_string()));
+    }
+
+    #[test]
+    fn lenient_ratings_skips_bad_entries() {
+        // A ratings array where one entry is malformed (missing `source`);
+        // the lenient deserializer should skip it and keep the valid ones.
+        let json = r#"{
+            "ratings": [
+                {"source": "imdb", "value": 8.5, "score": 85, "votes": 1000},
+                {"value": 7.0},
+                {"source": "tmdb", "value": 7.5, "score": 75, "votes": 500}
+            ]
+        }"#;
+        // With #[serde(default)] on source, a missing `source` just becomes "".
+        // The key test is that the array doesn't error entirely.
+        let resp: MdblistResponse = serde_json::from_str(json).expect("should not fail entire array");
+        assert_eq!(resp.ratings.len(), 3);
     }
 }

--- a/api/src/services/omdb.rs
+++ b/api/src/services/omdb.rs
@@ -23,9 +23,9 @@ pub struct OmdbResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct OmdbRating {
-    #[serde(rename = "Source")]
+    #[serde(rename = "Source", default)]
     pub source: String,
-    #[serde(rename = "Value")]
+    #[serde(rename = "Value", default)]
     pub value: String,
 }
 

--- a/api/src/services/ratings.rs
+++ b/api/src/services/ratings.rs
@@ -136,6 +136,8 @@ pub struct RatingsResult {
     pub tmdb_id: Option<u64>,
     pub tvdb_id: Option<u64>,
     pub imdb_id: Option<String>,
+    /// CSM age rating string (e.g. "12+"), sourced from MDBList's `age_rating` field.
+    pub csm_age: Option<String>,
 }
 
 pub async fn fetch_ratings(
@@ -229,9 +231,9 @@ async fn fetch_ratings_inner(
         );
     }
 
-    let (mdblist_badges, mdb_tmdb_id, mdb_tvdb_id, mdb_imdb_id) = match mdblist_raw {
-        Some((badges, tmdb_id, tvdb_id, imdb_id)) => (Some(badges), tmdb_id, tvdb_id, imdb_id),
-        None => (None, None, None, None),
+    let (mdblist_badges, mdb_tmdb_id, mdb_tvdb_id, mdb_imdb_id, mdb_csm_age) = match mdblist_raw {
+        Some((badges, tmdb_id, tvdb_id, imdb_id, csm_age)) => (Some(badges), tmdb_id, tvdb_id, imdb_id, csm_age),
+        None => (None, None, None, None, None),
     };
 
     let find_omdb = |src: RatingSource| -> Option<RatingBadge> {
@@ -270,6 +272,7 @@ async fn fetch_ratings_inner(
         tmdb_id: mdb_tmdb_id,
         tvdb_id: mdb_tvdb_id,
         imdb_id: mdb_imdb_id,
+        csm_age: mdb_csm_age,
     }
 }
 
@@ -1192,7 +1195,7 @@ fn mdblist_lookup_for(resolved: &ResolvedId) -> Option<MdblistLookup<'_>> {
 async fn fetch_mdblist_ratings(
     resolved: &ResolvedId,
     mdblist: Option<&MdblistClient>,
-) -> Option<(Vec<RatingBadge>, Option<u64>, Option<u64>, Option<String>)> {
+) -> Option<(Vec<RatingBadge>, Option<u64>, Option<u64>, Option<String>, Option<String>)> {
     let client = mdblist?;
 
     let resp = match mdblist_lookup_for(resolved)? {
@@ -1212,7 +1215,8 @@ async fn fetch_mdblist_ratings(
         },
     };
 
-    Some((mdblist_badges(&resp), resp.ids.tmdb, resp.ids.tvdb, resp.ids.imdb))
+    let csm_age = resp.csm_age();
+    Some((mdblist_badges(&resp), resp.ids.tmdb, resp.ids.tvdb, resp.ids.imdb, csm_age))
 }
 
 /// Map a raw MDBList response into rating badges.

--- a/api/src/services/tmdb.rs
+++ b/api/src/services/tmdb.rs
@@ -191,6 +191,7 @@ pub struct TmdbImage {
     pub iso_639_1: Option<String>,
     #[serde(default)]
     pub iso_3166_1: Option<String>,
+    #[serde(default)]
     pub vote_average: f64,
     /// Source aspect ratio (width/height) as reported by TMDB. Defaults to 0.0
     /// when absent, which the poster selector treats as "unknown" (never
@@ -199,13 +200,28 @@ pub struct TmdbImage {
     pub aspect_ratio: f64,
 }
 
+/// Deserialize a `Vec<TmdbImage>`, skipping individual entries that fail
+/// to parse rather than failing the whole array. TMDB can return large payloads
+/// with occasional malformed entries; a single bad entry must not drop all images.
+fn deserialize_lenient_images<'de, D>(deserializer: D) -> Result<Vec<TmdbImage>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let raw: Vec<serde_json::Value> = Vec::deserialize(deserializer)?;
+    Ok(raw
+        .into_iter()
+        .filter_map(|v| serde_json::from_value(v).ok())
+        .collect())
+}
+
 #[derive(Debug, Clone, serde::Deserialize)]
 pub struct TmdbImagesResponse {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_images")]
     pub backdrops: Vec<TmdbImage>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_images")]
     pub logos: Vec<TmdbImage>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_lenient_images")]
     pub posters: Vec<TmdbImage>,
 }
 

--- a/api/src/upgrade/mod.rs
+++ b/api/src/upgrade/mod.rs
@@ -1,6 +1,7 @@
 mod v001_backdrop_cache_keys;
 mod v002_backdrop_position_direction_cache;
 mod v003_badge_shape_background_cache;
+mod v004_csm_settings;
 
 use sea_orm::{ConnectionTrait, DatabaseConnection};
 
@@ -29,6 +30,9 @@ pub async fn run(
     run_once(db, "v003_badge_shape_background_cache", || {
         v003_badge_shape_background_cache::run(db, cache_dir, external_cache_only)
     })
+    .await?;
+
+    run_once(db, "v004_csm_settings", || v004_csm_settings::run(db))
     .await?;
 
     Ok(())

--- a/api/src/upgrade/v004_csm_settings.rs
+++ b/api/src/upgrade/v004_csm_settings.rs
@@ -1,0 +1,133 @@
+use sea_orm::{ConnectionTrait, DatabaseConnection};
+
+use crate::error::AppError;
+
+/// Add CommonSense Media (CSM) age-rating badge settings to `api_key_settings`.
+///
+/// Three columns are added with SQLite `ALTER TABLE … ADD COLUMN` (which is
+/// safe to run against an already-migrated database because we use `IF NOT
+/// EXISTS` guards in the upgrade tracking table). Default values match the
+/// application defaults defined in `services::db`:
+///
+/// - `csm_enabled`  INTEGER NOT NULL DEFAULT 0   (false)
+/// - `csm_position` TEXT    NOT NULL DEFAULT 'TopRight'
+/// - `csm_size`     TEXT    NOT NULL DEFAULT 'Medium'
+///
+/// SQLite `ADD COLUMN` with a DEFAULT is non-destructive and instantaneous —
+/// no data is rewritten. Existing rows automatically receive the default value.
+pub async fn run(db: &DatabaseConnection) -> Result<(), AppError> {
+    run_db(db).await
+}
+
+pub async fn run_db(db: &impl ConnectionTrait) -> Result<(), AppError> {
+    // SQLite does not support `ADD COLUMN IF NOT EXISTS`, so we attempt each
+    // ALTER and swallow the "duplicate column name" error, making this
+    // migration safe to re-run (e.g. after a partial failure).
+    for stmt in [
+        "ALTER TABLE api_key_settings ADD COLUMN csm_enabled  INTEGER NOT NULL DEFAULT 0",
+        "ALTER TABLE api_key_settings ADD COLUMN csm_position TEXT    NOT NULL DEFAULT 'TopRight'",
+        "ALTER TABLE api_key_settings ADD COLUMN csm_size     TEXT    NOT NULL DEFAULT 'Medium'",
+    ] {
+        match db.execute_unprepared(stmt).await {
+            Ok(_) => {}
+            Err(e) => {
+                let msg = e.to_string();
+                if msg.contains("duplicate column name") {
+                    tracing::debug!("v004: column already exists, skipping: {msg}");
+                } else {
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    tracing::info!("v004: csm_enabled / csm_position / csm_size columns ensured in api_key_settings");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sea_orm::{ConnectionTrait, Database, DatabaseBackend, Statement};
+
+    use super::*;
+
+    /// Spin up an in-memory SQLite DB, create a minimal `api_key_settings`
+    /// table, run the migration, and verify the three new columns exist.
+    #[tokio::test]
+    async fn adds_csm_columns() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+
+        db.execute_unprepared(
+            "CREATE TABLE api_key_settings (
+                api_key TEXT PRIMARY KEY
+            )",
+        )
+        .await
+        .unwrap();
+
+        run_db(&db).await.unwrap();
+
+        // Insert a row using the new columns — will fail if they don't exist.
+        db.execute(Statement::from_string(
+            DatabaseBackend::Sqlite,
+            "INSERT INTO api_key_settings (api_key, csm_enabled, csm_position, csm_size)
+             VALUES ('testkey', 0, 'TopRight', 'Medium')",
+        ))
+        .await
+        .expect("columns should exist after migration");
+    }
+
+    #[tokio::test]
+    async fn migration_is_idempotent() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+
+        db.execute_unprepared(
+            "CREATE TABLE api_key_settings (api_key TEXT PRIMARY KEY)",
+        )
+        .await
+        .unwrap();
+
+        // Running twice must not error.
+        run_db(&db).await.unwrap();
+        run_db(&db).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn defaults_applied_to_existing_rows() {
+        let db = Database::connect("sqlite::memory:").await.unwrap();
+
+        db.execute_unprepared(
+            "CREATE TABLE api_key_settings (api_key TEXT PRIMARY KEY)",
+        )
+        .await
+        .unwrap();
+
+        // Insert a row BEFORE migration — simulates an existing API key.
+        db.execute_unprepared(
+            "INSERT INTO api_key_settings (api_key) VALUES ('existingkey')",
+        )
+        .await
+        .unwrap();
+
+        run_db(&db).await.unwrap();
+
+        // The pre-existing row should have received the default values.
+        let row = db
+            .query_one(Statement::from_string(
+                DatabaseBackend::Sqlite,
+                "SELECT csm_enabled, csm_position, csm_size
+                 FROM api_key_settings WHERE api_key = 'existingkey'",
+            ))
+            .await
+            .unwrap()
+            .expect("row should exist");
+
+        let enabled: i32 = row.try_get("", "csm_enabled").unwrap();
+        let position: String = row.try_get("", "csm_position").unwrap();
+        let size: String = row.try_get("", "csm_size").unwrap();
+
+        assert_eq!(enabled, 0);
+        assert_eq!(position, "TopRight");
+        assert_eq!(size, "Medium");
+    }
+}

--- a/web/src/components/RenderSettingsForm.vue
+++ b/web/src/components/RenderSettingsForm.vue
@@ -59,6 +59,9 @@ export interface RenderSettings {
   logo_badge_background: string
   backdrop_badge_background: string
   episode_badge_background: string
+  csm_enabled: boolean
+  csm_position: string
+  csm_size: string
 }
 
 const props = defineProps<{
@@ -67,7 +70,7 @@ const props = defineProps<{
   loadSettings: () => Promise<RenderSettings | null>
   saveSettings: (s: SaveSettingsPayload) => Promise<string | null>
   resetSettings?: () => Promise<boolean>
-  fetchPreview: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string, posterFit?: string) => Promise<Response>
+  fetchPreview: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string, posterFit?: string, csmEnabled?: boolean, csmPosition?: string, csmSize?: string) => Promise<Response>
   fetchLogoPreview?: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string) => Promise<Response>
   fetchBackdropPreview?: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, position?: string, badgeDirection?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string, edgeInsetX?: number, edgeInsetY?: number) => Promise<Response>
   fetchEpisodePreview?: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, position?: string, badgeDirection?: string, blur?: boolean, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string) => Promise<Response>
@@ -116,6 +119,9 @@ const editPosterBadgeBackground = ref(props.settings.poster_badge_background || 
 const editLogoBadgeBackground = ref(props.settings.logo_badge_background || 'd')
 const editBackdropBadgeBackground = ref(props.settings.backdrop_badge_background || 'd')
 const editEpisodeBadgeBackground = ref(props.settings.episode_badge_background || 'd')
+const editCsmEnabled = ref(props.settings.csm_enabled ?? false)
+const editCsmPosition = ref(props.settings.csm_position || 'tr')
+const editCsmSize = ref(props.settings.csm_size || 'm')
 
 // Which edges the current backdrop position anchors to. The horizontal inset
 // only applies to left/right positions and the vertical inset only to top/bottom
@@ -170,6 +176,9 @@ function applySettings(s: RenderSettings) {
   editLogoBadgeBackground.value = s.logo_badge_background || 'd'
   editBackdropBadgeBackground.value = s.backdrop_badge_background || 'd'
   editEpisodeBadgeBackground.value = s.episode_badge_background || 'd'
+  editCsmEnabled.value = s.csm_enabled ?? false
+  editCsmPosition.value = s.csm_position || 'tr'
+  editCsmSize.value = s.csm_size || 'm'
 }
 const currentSettings = ref<RenderSettings>(props.settings)
 const saving = ref(false)
@@ -253,6 +262,9 @@ async function autoSave() {
       logo_badge_background: editLogoBadgeBackground.value,
       backdrop_badge_background: editBackdropBadgeBackground.value,
       episode_badge_background: editEpisodeBadgeBackground.value,
+      csm_enabled: editCsmEnabled.value,
+      csm_position: editCsmPosition.value,
+      csm_size: editCsmSize.value,
     })
     if (err) {
       error.value = err
@@ -279,7 +291,7 @@ async function autoSave() {
 
 // Auto-save on any setting change
 watch(
-  [editSource, editLang, editTextless, editRatingsLimit, editRatingsOrder, editRatingsExclude, editPosterPosition, editLogoRatingsLimit, editBackdropRatingsLimit, editPosterBadgeStyle, editLogoBadgeStyle, editBackdropBadgeStyle, editPosterLabelStyle, editLogoLabelStyle, editBackdropLabelStyle, editPosterBadgeDirection, editPosterBadgeSplit, editPosterFit, editPosterBadgeSize, editLogoBadgeSize, editBackdropBadgeSize, editBackdropPosition, editBackdropBadgeDirection, editBackdropEdgeInsetX, editBackdropEdgeInsetY, editEpisodeRatingsLimit, editEpisodeBadgeStyle, editEpisodeLabelStyle, editEpisodeBadgeSize, editEpisodePosition, editEpisodeBadgeDirection, editEpisodeBlur, editPosterBadgeShape, editLogoBadgeShape, editBackdropBadgeShape, editEpisodeBadgeShape, editPosterBadgeBackground, editLogoBadgeBackground, editBackdropBadgeBackground, editEpisodeBadgeBackground],
+  [editSource, editLang, editTextless, editRatingsLimit, editRatingsOrder, editRatingsExclude, editPosterPosition, editLogoRatingsLimit, editBackdropRatingsLimit, editPosterBadgeStyle, editLogoBadgeStyle, editBackdropBadgeStyle, editPosterLabelStyle, editLogoLabelStyle, editBackdropLabelStyle, editPosterBadgeDirection, editPosterBadgeSplit, editPosterFit, editPosterBadgeSize, editLogoBadgeSize, editBackdropBadgeSize, editBackdropPosition, editBackdropBadgeDirection, editBackdropEdgeInsetX, editBackdropEdgeInsetY, editEpisodeRatingsLimit, editEpisodeBadgeStyle, editEpisodeLabelStyle, editEpisodeBadgeSize, editEpisodePosition, editEpisodeBadgeDirection, editEpisodeBlur, editPosterBadgeShape, editLogoBadgeShape, editBackdropBadgeShape, editEpisodeBadgeShape, editPosterBadgeBackground, editLogoBadgeBackground, editBackdropBadgeBackground, editEpisodeBadgeBackground, editCsmEnabled, editCsmPosition, editCsmSize],
   () => {
     if (syncing) return
     autoSave()
@@ -370,7 +382,7 @@ let backdropPreviewTimer: ReturnType<typeof setTimeout> | null = null
 let episodePreviewTimer: ReturnType<typeof setTimeout> | null = null
 
 function updatePosterPreview() {
-  fetchPreviewImage(posterPreview.value, (_limit, order) => props.fetchPreview(editRatingsLimit.value, order, editPosterPosition.value, editPosterBadgeStyle.value, editPosterLabelStyle.value, editPosterBadgeDirection.value, editPosterBadgeSize.value, editRatingsExclude.value.join(','), editPosterBadgeSplit.value, editPosterBadgeShape.value, editPosterBadgeBackground.value, editPosterFit.value))
+  fetchPreviewImage(posterPreview.value, (_limit, order) => props.fetchPreview(editRatingsLimit.value, order, editPosterPosition.value, editPosterBadgeStyle.value, editPosterLabelStyle.value, editPosterBadgeDirection.value, editPosterBadgeSize.value, editRatingsExclude.value.join(','), editPosterBadgeSplit.value, editPosterBadgeShape.value, editPosterBadgeBackground.value, editPosterFit.value, editCsmEnabled.value, editCsmPosition.value, editCsmSize.value))
 }
 
 function updateLogoPreview() {
@@ -412,7 +424,7 @@ watch([editRatingsOrder, editRatingsExclude], () => {
 }, { deep: true })
 
 // Poster-only settings
-watch([editRatingsLimit, editPosterPosition, editPosterBadgeStyle, editPosterLabelStyle, editPosterBadgeDirection, editPosterBadgeSplit, editPosterFit, editPosterBadgeSize, editPosterBadgeShape, editPosterBadgeBackground], () => {
+watch([editRatingsLimit, editPosterPosition, editPosterBadgeStyle, editPosterLabelStyle, editPosterBadgeDirection, editPosterBadgeSplit, editPosterFit, editPosterBadgeSize, editPosterBadgeShape, editPosterBadgeBackground, editCsmEnabled, editCsmPosition, editCsmSize], () => {
   if (syncing) return
   if (posterPreviewTimer) clearTimeout(posterPreviewTimer)
   posterPreviewTimer = setTimeout(updatePosterPreview, 500)
@@ -745,6 +757,63 @@ function toggleExclude(key: string, checked: boolean) {
         <p class="text-xs text-muted-foreground">
           Splits badges across two opposite sides — left/right for a vertical layout, top/bottom for horizontal rows.
         </p>
+      </div>
+
+      <!-- CSM age-rating badge -->
+      <div class="space-y-1">
+        <div class="flex items-center gap-2">
+          <Checkbox
+            :id="inputId('csm-enabled')"
+            :model-value="editCsmEnabled"
+            data-testid="csm-enabled-checkbox"
+            @update:model-value="(v) => editCsmEnabled = !!v"
+          />
+          <Label :for="inputId('csm-enabled')">Show age rating badge (CommonSense Media)</Label>
+        </div>
+        <p class="text-xs text-muted-foreground">
+          Overlays a dark pill badge with the CSM age rating (e.g. "12+") sourced from MDBList. Requires MDBList to be configured.
+        </p>
+      </div>
+      <div v-if="editCsmEnabled" class="grid grid-cols-1 sm:grid-cols-2 gap-3 max-w-lg pl-6">
+        <div class="space-y-2">
+          <Label :for="inputId('csm-position')">Age badge position</Label>
+          <Select
+            :model-value="editCsmPosition"
+            @update:model-value="editCsmPosition = $event as string"
+          >
+            <SelectTrigger :id="inputId('csm-position')" class="max-w-xs" data-testid="csm-position-select">
+              <SelectValue placeholder="Select position" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="bc">Bottom Center</SelectItem>
+              <SelectItem value="tc">Top Center</SelectItem>
+              <SelectItem value="l">Left</SelectItem>
+              <SelectItem value="r">Right</SelectItem>
+              <SelectItem value="tl">Top Left</SelectItem>
+              <SelectItem value="tr">Top Right</SelectItem>
+              <SelectItem value="bl">Bottom Left</SelectItem>
+              <SelectItem value="br">Bottom Right</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        <div class="space-y-2">
+          <Label :for="inputId('csm-size')">Age badge size</Label>
+          <Select
+            :model-value="editCsmSize"
+            @update:model-value="editCsmSize = $event as string"
+          >
+            <SelectTrigger :id="inputId('csm-size')" class="max-w-xs" data-testid="csm-size-select">
+              <SelectValue placeholder="Select size" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="xs">Extra Small</SelectItem>
+              <SelectItem value="s">Small</SelectItem>
+              <SelectItem value="m">Medium</SelectItem>
+              <SelectItem value="l">Large</SelectItem>
+              <SelectItem value="xl">Extra Large</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
       </div>
     </div>
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -105,6 +105,9 @@ export interface SaveSettingsPayload {
   logo_badge_background: string
   backdrop_badge_background: string
   episode_badge_background: string
+  csm_enabled: boolean
+  csm_position: string
+  csm_size: string
 }
 
 /** Build a URL path with query parameters, omitting entries with nullish values. */
@@ -174,8 +177,8 @@ export const adminApi = {
     post(`/api/admin/episodes/${idType}/${idValue}/fetch`),
   purgeEpisode: (idType: string, idValue: string, scope: PurgeScope = 'title'): Promise<Response> =>
     del(purgeUrl('episodes', idType, idValue, scope)),
-  previewPoster: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string, posterFit?: string): Promise<Response> =>
-    get(buildUrl('/api/admin/preview/poster', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, position: posterPosition, badge_style: badgeStyle, label_style: labelStyle, badge_direction: badgeDirection, badge_size: badgeSize, split: posterSplit ? 'true' : undefined, badge_shape: badgeShape, badge_background: badgeBackground, fit: posterFit })),
+  previewPoster: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string, posterFit?: string, csmEnabled?: boolean, csmPosition?: string, csmSize?: string): Promise<Response> =>
+    get(buildUrl('/api/admin/preview/poster', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, position: posterPosition, badge_style: badgeStyle, label_style: labelStyle, badge_direction: badgeDirection, badge_size: badgeSize, split: posterSplit ? 'true' : undefined, badge_shape: badgeShape, badge_background: badgeBackground, fit: posterFit, csm_enabled: csmEnabled ? 'true' : undefined, csm_position: csmPosition, csm_size: csmSize })),
   previewLogo: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string): Promise<Response> =>
     get(buildUrl('/api/admin/preview/logo', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, badge_style: badgeStyle, label_style: labelStyle, badge_size: badgeSize, badge_shape: badgeShape, badge_background: badgeBackground })),
   previewBackdrop: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, position?: string, badgeDirection?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string, edgeInsetX?: number, edgeInsetY?: number): Promise<Response> =>
@@ -213,8 +216,8 @@ export const selfApi = {
     }),
   resetSettings: (): Promise<Response> =>
     keyRequest('/api/key/me/settings', { method: 'DELETE' }),
-  previewPoster: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string, posterFit?: string): Promise<Response> =>
-    keyRequest(buildUrl('/api/key/me/preview/poster', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, position: posterPosition, badge_style: badgeStyle, label_style: labelStyle, badge_direction: badgeDirection, badge_size: badgeSize, split: posterSplit ? 'true' : undefined, badge_shape: badgeShape, badge_background: badgeBackground, fit: posterFit })),
+  previewPoster: (ratingsLimit: number, ratingsOrder: string, posterPosition?: string, badgeStyle?: string, labelStyle?: string, badgeDirection?: string, badgeSize?: string, ratingsExclude?: string, posterSplit?: boolean, badgeShape?: string, badgeBackground?: string, posterFit?: string, csmEnabled?: boolean, csmPosition?: string, csmSize?: string): Promise<Response> =>
+    keyRequest(buildUrl('/api/key/me/preview/poster', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, position: posterPosition, badge_style: badgeStyle, label_style: labelStyle, badge_direction: badgeDirection, badge_size: badgeSize, split: posterSplit ? 'true' : undefined, badge_shape: badgeShape, badge_background: badgeBackground, fit: posterFit, csm_enabled: csmEnabled ? 'true' : undefined, csm_position: csmPosition, csm_size: csmSize })),
   previewLogo: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string): Promise<Response> =>
     keyRequest(buildUrl('/api/key/me/preview/logo', { ratings_limit: ratingsLimit, ratings_order: ratingsOrder, ratings_exclude: ratingsExclude, badge_style: badgeStyle, label_style: labelStyle, badge_size: badgeSize, badge_shape: badgeShape, badge_background: badgeBackground })),
   previewBackdrop: (ratingsLimit: number, ratingsOrder: string, badgeStyle?: string, labelStyle?: string, badgeSize?: string, position?: string, badgeDirection?: string, ratingsExclude?: string, badgeShape?: string, badgeBackground?: string, edgeInsetX?: number, edgeInsetY?: number): Promise<Response> =>


### PR DESCRIPTION
This started off as a way to add common sense media ratings to posters, i wanted something that could be in different locations than the shows scores/ratings and at a quick glance allow me to see suggested ages. not every show has a CSM rating so I switched to just using MDBlist's age rating.

<img width="443" height="943" alt="image" src="https://github.com/user-attachments/assets/de8666a0-2daa-4766-9cb6-e84370628afc" />

I did opt to stick to just posters, the checkbox enables the feature, its aware enough to give padding and priority to the shows ratings

<img width="434" height="933" alt="image" src="https://github.com/user-attachments/assets/966765ee-3bba-4bdb-8693-aeb1b9b4b6d2" />

This was 100% done thanks to claude so if you do not wish to accept it because of that I totally understand, I wanted to open it up to others as I've been self hosting it for a few months and just rebased it on the latest version.